### PR TITLE
로그인 페이지 초기 마크업 진행

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "14.0.4",
         "next-auth": "^5.0.0-beta.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-hook-form": "^7.49.3"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4963,6 +4964,22 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.49.3",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.3.tgz",
+      "integrity": "sha512-foD6r3juidAT1cOZzpmD/gOKt7fRsDhXXZ0y28+Al1CHgX+AY1qIN9VSIIItXRq1dN68QrRwl1ORFlwjBaAqeQ==",
+      "engines": {
+        "node": ">=18",
+        "pnpm": "8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "14.0.4",
     "next-auth": "^5.0.0-beta.4",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-hook-form": "^7.49.3"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/(beforelogin)/landing/page.tsx
+++ b/src/app/(beforelogin)/landing/page.tsx
@@ -1,7 +1,0 @@
-export default function Page() {
-  return (
-    <div>
-      <h1>Landing</h1>
-    </div>
-  );
-}

--- a/src/app/(beforelogin)/layout.module.scss
+++ b/src/app/(beforelogin)/layout.module.scss
@@ -1,0 +1,4 @@
+.container {
+  width: 100dvh;
+  height: 100dvh;
+}

--- a/src/app/(beforelogin)/layout.tsx
+++ b/src/app/(beforelogin)/layout.tsx
@@ -1,5 +1,7 @@
 import { ReactChildrenProps } from '@/types/common';
 
+import styles from './layout.module.scss';
+
 export default function BeforeLoginLayout({ children }: ReactChildrenProps) {
-  return <div>{children}</div>;
+  return <div className={styles.container}>{children}</div>;
 }

--- a/src/app/(beforelogin)/login/_components/Login.module.scss
+++ b/src/app/(beforelogin)/login/_components/Login.module.scss
@@ -1,0 +1,62 @@
+@import '@/app/_components/globals';
+
+.container {
+  @include flex-center;
+  @include full-size;
+
+  background-color: $login-backgroud-color;
+}
+
+.leftSection {
+  @include flex-center;
+
+  flex: 1;
+}
+
+.rightSection {
+  @include flex-center;
+
+  margin-right: 150px;
+  flex: 1;
+}
+
+.loginForm {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 550px;
+  height: 600px;
+  padding: 0 70px;
+  flex-direction: column;
+  background-color: white;
+
+  & > p:nth-child(1) {
+    margin: 5px 0;
+    font-size: 1.3rem;
+    font-weight: bolder;
+  }
+
+  & > p:nth-child(2) {
+    margin: 5px 0;
+    font-size: 1.1rem;
+  }
+}
+
+.text {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  color: #d9d9d9;
+
+  &::before,
+  &::after {
+    content: '';
+    flex: 1;
+    border-bottom: 2px solid black;
+  }
+
+  & > span {
+    padding: 0 30px;
+  }
+}

--- a/src/app/(beforelogin)/login/_components/Login.tsx
+++ b/src/app/(beforelogin)/login/_components/Login.tsx
@@ -1,0 +1,28 @@
+import styles from './Login.module.scss';
+
+import LoginForm from './LoginForm';
+import LoginMenus from './LoginMenus';
+import OAuthMenu from './OAuthMenu';
+
+const Login = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.leftSection}>LOGO</div>
+      <div className={styles.rightSection}>
+        <div className={styles.loginForm}>
+          <p>완벽한 발표를 위한 최고의 선택</p>
+          <p>(서비스 이름)에서 발표 연습을 해보세요</p>
+
+          <LoginForm />
+          <LoginMenus />
+          <div className={styles.text}>
+            <span>또는</span>
+          </div>
+          <OAuthMenu />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/app/(beforelogin)/login/_components/LoginForm.module.scss
+++ b/src/app/(beforelogin)/login/_components/LoginForm.module.scss
@@ -1,0 +1,48 @@
+@import '@/app/_components/globals';
+
+.container {
+  width: 100%;
+}
+
+.loginForm {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+}
+
+.loginInput {
+  display: flex;
+  margin: 5px 0;
+  padding: 5px;
+  border: 1px solid black;
+  flex-direction: column;
+  border-radius: 5px;
+
+  label {
+    font-size: 0.9rem;
+  }
+
+  &:focus-within {
+    border: 2px solid black;
+  }
+
+  .input {
+    height: 35px;
+    border: none;
+    font-size: 1rem;
+
+    &:focus {
+      outline: none;
+    }
+  }
+}
+
+.submitButton {
+  @include pure-button;
+
+  height: 45px;
+  border: none;
+  color: white;
+  margin-top: 10px;
+  background-color: black;
+}

--- a/src/app/(beforelogin)/login/_components/LoginForm.tsx
+++ b/src/app/(beforelogin)/login/_components/LoginForm.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { FieldValues, useForm } from 'react-hook-form';
+
+import styles from './LoginForm.module.scss';
+
+import Button from '@/app/_components/_elements/Button';
+
+interface LoginformType {
+  email: string;
+  password: number;
+}
+
+function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, isSubmitted, errors },
+  } = useForm<LoginformType>();
+
+  const loginSubmit = (data: FieldValues) => {
+    alert(JSON.stringify(data));
+  };
+
+  return (
+    <div className={styles.container}>
+      {/* data가 사용자가 입력한 최종 데이터 */}
+      <form className={styles.loginForm} onSubmit={handleSubmit((data) => loginSubmit(data))}>
+        <div className={styles.loginInput}>
+          <label htmlFor="email">이메일</label>
+          <input
+            className={styles.input}
+            id="email"
+            type="email"
+            placeholder="이메일을 입력하세요"
+            aria-invalid={isSubmitted ? (errors.email ? 'true' : 'false') : undefined}
+            {...register('email', {
+              required: '이메일은 필수 입력입니다.',
+              pattern: {
+                value: /\S+@\S+\.\S+/,
+                message: '이메일 형식에 맞지 않습니다.',
+              },
+            })}
+          />
+        </div>
+        {errors.email && (
+          <small style={{ color: 'red' }} role="alert">
+            {errors.email?.message}
+          </small>
+        )}
+        <div className={styles.loginInput}>
+          <label htmlFor="password">비밀번호</label>
+          <input
+            className={styles.input}
+            id="password"
+            type="password"
+            placeholder="비밀번호를 입력하세요"
+            aria-invalid={isSubmitted ? (errors.password ? 'true' : 'false') : undefined}
+            {...register('password', {
+              required: '비밀번호는 필수 입력입니다.',
+              minLength: {
+                value: 8,
+                message: '8자리 이상 입력하세요',
+              },
+            })}
+          />
+        </div>
+        {errors.password && (
+          <small style={{ color: 'red' }} role="alert">
+            {errors.password?.message}
+          </small>
+        )}
+        <Button
+          _disabled={isSubmitting}
+          _onClick={() => {}}
+          _type="submit"
+          content={'로그인'}
+          _className={styles.submitButton}
+        ></Button>
+      </form>
+    </div>
+  );
+}
+
+export default LoginForm;

--- a/src/app/(beforelogin)/login/_components/LoginMenus.module.scss
+++ b/src/app/(beforelogin)/login/_components/LoginMenus.module.scss
@@ -1,0 +1,24 @@
+@import '@/app/_components/globals';
+
+.container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.list {
+  display: flex;
+  padding: 0;
+
+  li {
+    &:not(:last-child) {
+      border-right: 1px solid #d9d9d9;
+    }
+  }
+}
+
+.menuButton {
+  @include pure-button;
+
+  color: #d9d9d9;
+}

--- a/src/app/(beforelogin)/login/_components/LoginMenus.tsx
+++ b/src/app/(beforelogin)/login/_components/LoginMenus.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import List from '@/app/_components/_elements/List';
+import Button from '@/app/_components/_elements/Button';
+
+import styles from './LoginMenus.module.scss';
+
+import { ListInfoType } from '@/types/common';
+
+const LoginMenus = () => {
+  const listArr: ListInfoType = [
+    {
+      content: (
+        <Button content="회원가입" _className={styles.menuButton} _onClick={() => {}}></Button>
+      ),
+    },
+    {
+      content: (
+        <Button content="아이디 찾기" _className={styles.menuButton} _onClick={() => {}}></Button>
+      ),
+    },
+    {
+      content: (
+        <Button content="비밀번호 찾기" _className={styles.menuButton} _onClick={() => {}}></Button>
+      ),
+    },
+  ];
+
+  return (
+    <div className={styles.container}>
+      <ul className={styles.list}>
+        <List listArr={listArr} />
+      </ul>
+    </div>
+  );
+};
+
+export default LoginMenus;

--- a/src/app/(beforelogin)/login/_components/OAuthMenu.module.scss
+++ b/src/app/(beforelogin)/login/_components/OAuthMenu.module.scss
@@ -1,0 +1,16 @@
+@import '@/app/_components/globals';
+
+.container {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+
+  ul {
+    display: flex;
+    gap: 20px;
+  }
+}
+
+.authButtons {
+  @include pure-button;
+}

--- a/src/app/(beforelogin)/login/_components/OAuthMenu.tsx
+++ b/src/app/(beforelogin)/login/_components/OAuthMenu.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import styles from './OAuthMenu.module.scss';
+
+import { ListInfoType } from '@/types/common';
+
+import List from '@/app/_components/_elements/List';
+import Button from '@/app/_components/_elements/Button';
+
+const OAuthMenu = () => {
+  const TmpSvg = (
+    <svg width="37" height="36" viewBox="0 0 37 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="18.5" cy="18" r="18" fill="#D9D9D9" />
+    </svg>
+  );
+  const listArr: ListInfoType = [
+    {
+      content: (
+        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      ),
+    },
+    {
+      content: (
+        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      ),
+    },
+    {
+      content: (
+        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      ),
+    },
+    {
+      content: (
+        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      ),
+    },
+  ];
+  return (
+    <div className={styles.container}>
+      <ul className={styles.authButtonList}>
+        <List listArr={listArr} />
+      </ul>
+    </div>
+  );
+};
+
+export default OAuthMenu;

--- a/src/app/(beforelogin)/login/page.tsx
+++ b/src/app/(beforelogin)/login/page.tsx
@@ -1,7 +1,11 @@
-export default function Page() {
+import Login from './_components/Login';
+
+const page = () => {
   return (
     <div>
-      <h1>Login</h1>
+      <Login />
     </div>
   );
-}
+};
+
+export default page;

--- a/src/app/(beforelogin)/page.tsx
+++ b/src/app/(beforelogin)/page.tsx
@@ -1,7 +1,3 @@
 export default function Page() {
-  return (
-    <div>
-      <h1>Main</h1>
-    </div>
-  );
+  return <div>렌딩 페이지</div>;
 }

--- a/src/app/_components/_elements/Button.tsx
+++ b/src/app/_components/_elements/Button.tsx
@@ -1,0 +1,17 @@
+import { ButtonInfoType } from '@/types/common';
+
+const Button = ({
+  _className,
+  _disabled = false,
+  _type = 'button',
+  content,
+  _onClick,
+}: ButtonInfoType) => {
+  return (
+    <button className={_className} disabled={_disabled} type={_type} onClick={_onClick}>
+      {content}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/app/_components/_elements/List.tsx
+++ b/src/app/_components/_elements/List.tsx
@@ -1,0 +1,17 @@
+import { ListInfoType } from '@/types/common';
+
+const List = ({ listArr }: { listArr: ListInfoType }) => {
+  return (
+    <>
+      {listArr.map((item, index) => {
+        return (
+          <li key={index} className={item._className}>
+            {item.content}
+          </li>
+        );
+      })}
+    </>
+  );
+};
+
+export default List;

--- a/src/app/_components/globals.scss
+++ b/src/app/_components/globals.scss
@@ -1,0 +1,18 @@
+@mixin flex-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@mixin full-size {
+  width: 100dvw;
+  height: 100dvh;
+}
+
+@mixin pure-button {
+  background-color: transparent;
+  cursor: pointer;
+  border: none;
+}
+
+$login-backgroud-color: #d5d5d5;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,3 +14,11 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+ul {
+  padding: 0;
+}
+
+li {
+  list-style: none;
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -3,3 +3,18 @@ import { ReactNode } from 'react';
 export interface ReactChildrenProps {
   children: ReactNode;
 }
+
+export interface ButtonInfoType {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any;
+  _onClick: () => void;
+  _type?: 'button' | 'submit' | 'reset';
+  _disabled?: boolean;
+  _className?: string; // 각 버튼의 className
+}
+
+export type ListInfoType = Array<{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  content: any;
+  _className?: string; // 각 리스트의 className
+}>;


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 로그인 페이지 마크업 구현

<br/>

### 📷 스크린 샷 (선택)
![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/41838904-b65d-4c65-940b-53a907be8324)
<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 입력 폼에 대한 부분은 `react-hook-form`을 사용했고 아직 서버로 연결은 해두지 않았습니다
- `button`과 `li` 에 대한 공통 컴포넌트를 `app/_components/_elements ` 에 생성하고 이를 재사용 했습니다
- 최초 진입 시 랜딩페이지를 보여줘야 하므로 로그인 페이지는 http://localhost:3000/login 로 진입해야 합니다


<br/>

### 🧪 테스트 범위 (선택)
