### PR TITLE
공통 엘리먼트 타입 수정

### DIFF
--- a/src/app/(afterlogin)/layout.tsx
+++ b/src/app/(afterlogin)/layout.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next';
 
 import RQProvider from './_components/RQProvider';
-
 import { ReactChildrenProps } from '@/types/common';
 
 export const metadata: Metadata = {

--- a/src/app/(beforelogin)/login/_components/LoginForm.tsx
+++ b/src/app/(beforelogin)/login/_components/LoginForm.tsx
@@ -71,10 +71,10 @@ function LoginForm() {
           </small>
         )}
         <Button
-          _disabled={isSubmitting}
-          _onClick={() => {}}
-          _type="submit"
-          content={'로그인'}
+          disabled={isSubmitting}
+          onClick={() => {}}
+          type="submit"
+          _content={'로그인'}
           _className={styles.submitButton}
         ></Button>
       </form>

--- a/src/app/(beforelogin)/login/_components/LoginMenus.tsx
+++ b/src/app/(beforelogin)/login/_components/LoginMenus.tsx
@@ -5,23 +5,24 @@ import Button from '@/app/_components/_elements/Button';
 
 import styles from './LoginMenus.module.scss';
 
-import { ListInfoType } from '@/types/common';
+import { ListInfoType } from '@/types/element';
 
 const LoginMenus = () => {
   const listArr: ListInfoType = [
     {
-      content: (
-        <Button content="회원가입" _className={styles.menuButton} _onClick={() => {}}></Button>
+      _content: (
+        <Button _content="회원가입" _className={styles.menuButton} onClick={() => {}}></Button>
+      ),
+      // style: { backgroundColor: 'blue' },
+    },
+    {
+      _content: (
+        <Button _content="아이디 찾기" _className={styles.menuButton} onClick={() => {}}></Button>
       ),
     },
     {
-      content: (
-        <Button content="아이디 찾기" _className={styles.menuButton} _onClick={() => {}}></Button>
-      ),
-    },
-    {
-      content: (
-        <Button content="비밀번호 찾기" _className={styles.menuButton} _onClick={() => {}}></Button>
+      _content: (
+        <Button _content="비밀번호 찾기" _className={styles.menuButton} onClick={() => {}}></Button>
       ),
     },
   ];

--- a/src/app/(beforelogin)/login/_components/OAuthMenu.tsx
+++ b/src/app/(beforelogin)/login/_components/OAuthMenu.tsx
@@ -2,7 +2,7 @@
 
 import styles from './OAuthMenu.module.scss';
 
-import { ListInfoType } from '@/types/common';
+import { ListInfoType } from '@/types/element';
 
 import List from '@/app/_components/_elements/List';
 import Button from '@/app/_components/_elements/Button';
@@ -15,23 +15,24 @@ const OAuthMenu = () => {
   );
   const listArr: ListInfoType = [
     {
-      content: (
-        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      _content: (
+        <Button _content={TmpSvg} _className={styles.authButtons} onClick={() => {}}></Button>
+      ),
+      // style: { backgroundColor: 'blue' },
+    },
+    {
+      _content: (
+        <Button _content={TmpSvg} _className={styles.authButtons} onClick={() => {}}></Button>
       ),
     },
     {
-      content: (
-        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      _content: (
+        <Button _content={TmpSvg} _className={styles.authButtons} onClick={() => {}}></Button>
       ),
     },
     {
-      content: (
-        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
-      ),
-    },
-    {
-      content: (
-        <Button content={TmpSvg} _onClick={() => {}} _className={styles.authButtons}></Button>
+      _content: (
+        <Button _content={TmpSvg} _className={styles.authButtons} onClick={() => {}}></Button>
       ),
     },
   ];

--- a/src/app/_components/_elements/Button.tsx
+++ b/src/app/_components/_elements/Button.tsx
@@ -1,15 +1,9 @@
-import { ButtonInfoType } from '@/types/common';
+import { ButtonInfoType } from '@/types/element';
 
-const Button = ({
-  _className,
-  _disabled = false,
-  _type = 'button',
-  content,
-  _onClick,
-}: ButtonInfoType) => {
+const Button = ({ _className, _content, ...rest }: ButtonInfoType) => {
   return (
-    <button className={_className} disabled={_disabled} type={_type} onClick={_onClick}>
-      {content}
+    <button className={_className} {...rest}>
+      {_content}
     </button>
   );
 };

--- a/src/app/_components/_elements/Input.tsx
+++ b/src/app/_components/_elements/Input.tsx
@@ -1,0 +1,10 @@
+import React, { forwardRef } from 'react';
+import { InputInfoType } from '@/types/element';
+
+const Input = forwardRef<HTMLInputElement, InputInfoType>(({ _className, ...rest }, ref) => {
+  return <input ref={ref} className={_className} {...rest} />;
+});
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/app/_components/_elements/List.tsx
+++ b/src/app/_components/_elements/List.tsx
@@ -1,12 +1,12 @@
-import { ListInfoType } from '@/types/common';
+import { ListInfoType } from '@/types/element';
 
 const List = ({ listArr }: { listArr: ListInfoType }) => {
   return (
     <>
       {listArr.map((item, index) => {
         return (
-          <li key={index} className={item._className}>
-            {item.content}
+          <li key={index} className={item._className} {...item}>
+            {item._content}
           </li>
         );
       })}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -3,18 +3,3 @@ import { ReactNode } from 'react';
 export interface ReactChildrenProps {
   children: ReactNode;
 }
-
-export interface ButtonInfoType {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: any;
-  _onClick: () => void;
-  _type?: 'button' | 'submit' | 'reset';
-  _disabled?: boolean;
-  _className?: string; // 각 버튼의 className
-}
-
-export type ListInfoType = Array<{
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  content: any;
-  _className?: string; // 각 리스트의 className
-}>;

--- a/src/types/element.ts
+++ b/src/types/element.ts
@@ -1,0 +1,19 @@
+import { ButtonHTMLAttributes, InputHTMLAttributes, LiHTMLAttributes, ReactNode } from 'react';
+
+export interface ButtonInfoType extends ButtonHTMLAttributes<HTMLButtonElement> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _content: React.ReactNode;
+  _className?: string;
+  // _onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+interface SingleListType extends LiHTMLAttributes<HTMLLIElement> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _content: React.ReactNode;
+  _className?: string;
+}
+export type ListInfoType = SingleListType[];
+
+export interface InputInfoType extends InputHTMLAttributes<HTMLInputElement> {
+  _className?: string;
+}


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 공통 엘리먼트의 재사용성을 높이기 위해, 기존 HTML 엘리먼트들의 타입을 extends하는 방식으로 변경해서 실제 모든 속성들을 받아서 사용할 수 있도록 했습니다.
- 엘리먼트의 내용에 사용되는_content와 스타일링을 위한 _className만 추가했습니다 <br> ( 사실 className도 기본 내장 속성이므로 사용할 필요가 없었지만,  className으로 스타일링을 진행한다는 것을 명시하기 위해 일부러 추가했습니다 )
- input에는 React의 useRef도 적용할 수 있도록 했습니다.

<br/>

### 📷 스크린 샷 (선택)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

진행 중이던 상황에서 pull 한번만 해주세요

<br/>

### 🧪 테스트 범위 (선택)

