### PR TITLE
전역 모달 스토어 및 컴포넌트 생성

### DIFF
--- a/src/app/(afterlogin)/element-test/page.tsx
+++ b/src/app/(afterlogin)/element-test/page.tsx
@@ -26,17 +26,17 @@ export default function Page() {
   return (
     <>
       <div>
-        <Checkbox _label="가능여부" _isChecked={isAvailable} _onChange={handleOnChange}></Checkbox>
+        <Checkbox _label="가능여부" _isChecked={isAvailable} onChange={handleOnChange}></Checkbox>
         <ToggleButton
           _label="알람? (acteved label)"
           _isChecked={isUsedAlarm}
-          _onChange={handleOnChangeAlarm}
           _activedLabel
+          onChange={handleOnChangeAlarm}
         ></ToggleButton>
         <ToggleButton
           _label="알람?"
           _isChecked={isUsedAlarm}
-          _onChange={handleOnChangeAlarm}
+          onChange={handleOnChangeAlarm}
         ></ToggleButton>
       </div>
       <div>

--- a/src/app/(afterlogin)/layout.tsx
+++ b/src/app/(afterlogin)/layout.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next';
 
 import RQProvider from './_components/RQProvider';
 import { ReactChildrenProps } from '@/types/common';
+import AlertModal from '../_components/_modules/AlertModal';
+import ConfirmModal from '../_components/_modules/ConfirmModal';
 
 export const metadata: Metadata = {
   title: '홈',
@@ -13,6 +15,8 @@ export default function AfterLoginLayout({ children }: ReactChildrenProps) {
     <div>
       <RQProvider>
         <div>{children}</div>
+        <AlertModal />
+        <ConfirmModal />
       </RQProvider>
     </div>
   );

--- a/src/app/(afterlogin)/practice/_components/Recorder.tsx
+++ b/src/app/(afterlogin)/practice/_components/Recorder.tsx
@@ -22,7 +22,6 @@ const Recorder = () => {
 
         mediaRecorder.onstop = () => {
           const audioBlob = new Blob(audioChunks, { type: 'audio/mp3' }); // 오디오 파일 형식 확인 필요
-          console.log(audioBlob);
           setAudioBlob(audioBlob);
         };
 

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/ControlButtons.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/ControlButtons.tsx
@@ -1,11 +1,16 @@
 'use client';
 
-import Image from 'next/image';
 import { Dispatch, MouseEvent, SetStateAction } from 'react';
+
+import Image from 'next/image';
+
 import Button from '@/app/_components/_elements/Button';
+
 import { PagesDataType } from '@/types/service';
+
 import styles from './ControlButtons.module.scss';
 import classNames from 'classnames/bind';
+
 import { DragDropContext, Draggable, DropResult, Droppable } from 'react-beautiful-dnd';
 
 const cx = classNames.bind(styles);

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/InputSection.module.scss
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/InputSection.module.scss
@@ -60,3 +60,7 @@
     background-color: #d9d9d9;
   }
 }
+
+.modalContent {
+  margin: 0;
+}

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/InputSection.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/InputSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { PagesDataType } from '@/types/service';
 import styles from './InputSection.module.scss';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
 import UploadTitle from './UploadTitle';
 import UploadScript from './UploadScript';
 import UploadMemo from './UploadMemo';
@@ -10,6 +10,7 @@ import UploadTimer from './UploadTimer';
 import Button from '@/app/_components/_elements/Button';
 import UploadPpt from './UploadPpt';
 import ControlButtons from './ControlButtons';
+import { useAlertModalStore } from '@/store/modal';
 
 interface InputSectionProps {
   presentationData: PagesDataType;
@@ -27,6 +28,16 @@ const InputSection = ({
   initialState,
   slug,
 }: InputSectionProps) => {
+  const { openModal } = useAlertModalStore();
+
+  const openModalWithData = (data: ReactNode) =>
+    // ModalData 생성
+    openModal({
+      children: data,
+      onSubmit: () => console.log('submit'),
+      onCancel: () => console.log('cancel'),
+    });
+
   return (
     <div className={styles.container}>
       <div className={styles.leftSectionWrapper}>
@@ -66,7 +77,13 @@ const InputSection = ({
           <UploadTimer time={presentationData.time} setPresentationData={setPresentationData} />
 
           <div className={styles.saveButtons}>
-            <Button _content={<p>저장</p>} onClick={() => {}} className={styles.save} />
+            <Button
+              _content={<p>저장</p>}
+              onClick={() => {
+                openModalWithData(<p className={styles.modalContent}>저장이 완료되었습니다</p>);
+              }}
+              className={styles.save}
+            />
             <Button
               _content={<p>발표 연습 시작하기</p>}
               onClick={() => {}}

--- a/src/app/(afterlogin)/presentation/upload/[id]/page.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from 'react';
 import CreatePresentation from './_component/CreatePresentation';
 import EditPresentation from './_component/EditPresentation';
-import styles from './page.module.scss';
 import Spinner from './_component/Spinner';
 
 interface PageProps {

--- a/src/app/(beforelogin)/login/_components/OAuthMenu.tsx
+++ b/src/app/(beforelogin)/login/_components/OAuthMenu.tsx
@@ -18,7 +18,6 @@ const OAuthMenu = () => {
       _content: (
         <Button _content={TmpSvg} _className={styles.authButtons} onClick={() => {}}></Button>
       ),
-      // style: { backgroundColor: 'blue' },
     },
     {
       _content: (

--- a/src/app/_components/_elements/Checkbox.tsx
+++ b/src/app/_components/_elements/Checkbox.tsx
@@ -1,9 +1,9 @@
 import { CheckboxProps } from '@/types/element';
 
-const Checkbox = ({ _label, _isChecked, _onChange, ...rest }: CheckboxProps) => {
+const Checkbox = ({ _label, _isChecked, ...rest }: CheckboxProps) => {
   return (
     <label htmlFor="checkbox">
-      <input id="checkbox" type="checkbox" checked={_isChecked} onChange={_onChange} {...rest} />
+      <input id="checkbox" type="checkbox" checked={_isChecked} {...rest} />
       {_label}
     </label>
   );

--- a/src/app/_components/_elements/ToggleButton.tsx
+++ b/src/app/_components/_elements/ToggleButton.tsx
@@ -2,13 +2,7 @@ import { ToggleButtonProps } from '@/types/element';
 import { combineClassName } from '@/app/_utils/style';
 import styles from './ToggleButton.module.scss';
 
-const ToggleButton = ({
-  _label,
-  _isChecked,
-  _activedLabel,
-  _onChange,
-  ...rest
-}: ToggleButtonProps) => {
+const ToggleButton = ({ _label, _isChecked, _activedLabel, ...rest }: ToggleButtonProps) => {
   return (
     <>
       {_activedLabel ? (
@@ -19,7 +13,6 @@ const ToggleButton = ({
               role="switch"
               type="checkbox"
               checked={_isChecked}
-              onChange={_onChange}
               {...rest}
             />
             {_label}
@@ -32,7 +25,6 @@ const ToggleButton = ({
             role="switch"
             type="checkbox"
             checked={_isChecked}
-            onChange={_onChange}
             {...rest}
           />
           <label>{_label}</label>

--- a/src/app/_components/_modules/AlertModal.module.scss
+++ b/src/app/_components/_modules/AlertModal.module.scss
@@ -1,0 +1,50 @@
+@import '@/app/_components/globals';
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+.modalContainer {
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  width: 250px;
+  height: 35px;
+  transform: translate(-50%, -50%);
+  animation: fade-in 0.5s;
+}
+
+.modalContainer.fadeOut {
+  animation: fade-out 0.8s; // 0.5보다 조금 더 늘려야 함
+}
+
+.modalContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  width: 100%;
+  height: 100%;
+  background-color: darkgray;
+  border-radius: 20px;
+
+  .closeButton {
+    @include pure-button;
+  }
+}

--- a/src/app/_components/_modules/AlertModal.tsx
+++ b/src/app/_components/_modules/AlertModal.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { useAlertModalStore } from '@/store/modal';
+
+import styles from './AlertModal.module.scss';
+
+import Button from '../_elements/Button';
+
+import classNames from 'classnames/bind';
+
+const AlertModal = () => {
+  const { isOpen, modalData, closeModal } = useAlertModalStore();
+  const { children } = modalData;
+  const [fadeOut, setFadeOut] = useState(false);
+
+  const cx = classNames.bind(styles);
+
+  useEffect(() => {
+    if (isOpen) {
+      setFadeOut(false);
+      const timer = setTimeout(() => {
+        setFadeOut(true);
+        setTimeout(closeModal, 500); // 0.5초 후에 모달창 닫기
+      }, 1000); // 1초 후에 fadeOut 시작
+
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen, closeModal]);
+
+  if (!isOpen) {
+    return <></>;
+  }
+
+  return (
+    <div className={cx(['modalContainer', fadeOut && 'fadeOut'])}>
+      <div className={styles.modalContent}>
+        <div>{children}</div>
+        <Button onClick={() => setFadeOut(true)} _content={'x'} _className={styles.closeButton} />
+      </div>
+    </div>
+  );
+};
+
+export default AlertModal;

--- a/src/app/_components/_modules/ConfirmModal.module.scss
+++ b/src/app/_components/_modules/ConfirmModal.module.scss
@@ -1,0 +1,21 @@
+.modalContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  inset: 0;
+  background-color: rgb(0 0 0 / 50%);
+}
+
+.modalContent {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  top: 5%;
+  width: 500px;
+  height: 700px;
+  background: #fff;
+  border-radius: 20px;
+  flex-direction: column;
+}

--- a/src/app/_components/_modules/ConfirmModal.tsx
+++ b/src/app/_components/_modules/ConfirmModal.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useConfirmModalStore } from '@/store/modal';
+
+import styles from './ConfirmModal.module.scss';
+
+const ConfirmModal = () => {
+  const { isOpen, modalData, closeModal } = useConfirmModalStore();
+
+  const { children, onCancel, onSubmit } = modalData;
+
+  if (!isOpen) {
+    return <></>;
+  }
+
+  const onCancelInternal = () => {
+    onCancel?.();
+    closeModal();
+  };
+
+  const onSubmitInternal = () => {
+    onSubmit?.();
+    closeModal();
+  };
+
+  return (
+    <div className={styles.modalContainer}>
+      <div className={styles.modalContent}>
+        <div onClick={closeModal}>x</div>
+        <div>
+          <div>{children}</div>
+          <div>
+            <button onClick={onCancelInternal}>cancel</button>
+            <button onClick={onSubmitInternal}>submit</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/app/_components/_modules/ImagePreview.tsx
+++ b/src/app/_components/_modules/ImagePreview.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-
 interface Props {
   selectedFiles: File[];
   base64Strings: string[];

--- a/src/app/_components/_modules/ImageUploader.tsx
+++ b/src/app/_components/_modules/ImageUploader.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import useImageUploader from '@/app/_hooks/useImageUploader';
-import { ChangeEvent, InputHTMLAttributes, useState } from 'react';
+import { ChangeEvent, InputHTMLAttributes } from 'react';
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {
   _classname?: string;

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -1,20 +1,33 @@
 import { ReactNode } from 'react';
 import { create } from 'zustand';
 
+/** 모달 데이터 타입*/
 type ModalData = {
+  /** 모달 컨텐츠 */
   children?: ReactNode;
+
+  /** 취소버튼 클릭시 트리거되는 콜백 */
   onCancel?: () => unknown;
+
+  /** submit버튼 클릭시 트리거되는 콜백 */
   onSubmit?: () => unknown;
 };
 
+/** 모달 스토어 타입 */
 interface ModalStore {
+  /** 모달 렌더링 유무 플래그 */
   isOpen: boolean;
+
+  /** 모달 데이터를 기반으로 모달을 생성하는 함수 */
   openModal: (modalData: ModalData) => unknown;
+  /** 모달을 닫는 함수 */
   closeModal: () => unknown;
+
+  /** 모달창에 사용되는 모달 데이터 */
   modalData: ModalData;
 }
 
-// confirm용 모달
+// confirm용 모달 스토어
 export const useConfirmModalStore = create<ModalStore>((set) => ({
   isOpen: false,
   modalData: {} as ModalData,
@@ -28,7 +41,7 @@ export const useConfirmModalStore = create<ModalStore>((set) => ({
   },
 }));
 
-// alert용 모달
+// alert용 모달 스토어
 export const useAlertModalStore = create<ModalStore>((set) => ({
   isOpen: false,
   modalData: {} as ModalData,

--- a/src/store/modal.ts
+++ b/src/store/modal.ts
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import { create } from 'zustand';
+
+type ModalData = {
+  children?: ReactNode;
+  onCancel?: () => unknown;
+  onSubmit?: () => unknown;
+};
+
+interface ModalStore {
+  isOpen: boolean;
+  openModal: (modalData: ModalData) => unknown;
+  closeModal: () => unknown;
+  modalData: ModalData;
+}
+
+// confirm용 모달
+export const useConfirmModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  modalData: {} as ModalData,
+
+  openModal: (modalData: ModalData) => {
+    set((state) => ({ isOpen: true, modalData: { ...modalData } }));
+  },
+
+  closeModal: () => {
+    set((state) => ({ isOpen: false, modalData: {} }));
+  },
+}));
+
+// alert용 모달
+export const useAlertModalStore = create<ModalStore>((set) => ({
+  isOpen: false,
+  modalData: {} as ModalData,
+
+  openModal: (modalData: ModalData) => {
+    set((state) => ({ isOpen: true, modalData: { ...modalData } }));
+  },
+
+  closeModal: () => {
+    set((state) => ({ isOpen: false, modalData: {} }));
+  },
+}));

--- a/src/types/element.ts
+++ b/src/types/element.ts
@@ -8,11 +8,15 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   _className?: string;
 }
 
-// TODO: 타입 주석 필요
+/** 단일 리스트(li) 타입  */
 interface SingleList extends LiHTMLAttributes<HTMLLIElement> {
+  /** li 내 자식 컴포넌트 */
   _content: React.ReactNode;
+  /** li 태그 스타일  */
   _className?: string;
 }
+
+/** ul안에 들어갈 li태그 배열 */
 export type ListProps = SingleList[];
 
 /** 인풋 컴포넌트 prop */
@@ -27,8 +31,6 @@ export interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
   _label?: string;
   /** 체크 여부 */
   _isChecked: boolean;
-  /** 체크 여부 변경 핸들러 */
-  _onChange: () => void;
 }
 
 /** 토글 버튼 컴포넌트 prop */


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 전역으로 사용되는 모달창 (alert용, confirm용)을 생성합니다

### 필요한 기능 
- 클릭했을 때 모달이 띄워져야 한다.
- 모달이 띄워졌을 때
    - 주변 배경을 클릭할 수 없다 - confirm
    - 주변 배경을 클릭할 수 있다 - 1회성 alert
- 모달을 닫는 close 버튼과 이후 작업을 수행할 submit 버튼이 있다
- 재사용이 가능해야 한다

### 전역 모달에 사용되는 타입은 다음과 같습니다

```tsx
interface ModalStore {

  // 모달의 렌더링 유무 플래그
  isOpen: boolean; 

  // 모달을 렌더링 하는 콜백
  openModal: (modalData: ModalData) => unknown; 

  // 모달을 닫는 콜백
  closeModal: () => unknown; 

 // 모달에 사용될 로직과 컨텐츠들
  modalData: { 
    children?: ReactNode; // 모달에 사용될 컨텐츠
    onCancel?: () => unknown; // 모달을 닫을 때 트리거 할 로직
    onSubmit?: () => unknown; // 모달을 submit할 때 트리거 할 로직
  };

}
```

위 타입을 기반으로 모달을 관리하는 전역 스토어를 생성합니다
```tsx
import { ReactNode } from 'react';
import { create } from 'zustand';

type ModalData = {
  children?: ReactNode;
  onCancel?: () => unknown;
  onSubmit?: () => unknown;
};

interface ModalStore {
  isOpen: boolean;
  openModal: (modalData: ModalData) => unknown;
  closeModal: () => unknown;
  modalData: ModalData;
}

// confirm용 모달 스토어
export const useConfirmModalStore = create<ModalStore>((set) => ({
  isOpen: false,
  modalData: {} as ModalData,

  openModal: (modalData: ModalData) => {
    set((state) => ({ isOpen: true, modalData: { ...modalData } }));
  },

  closeModal: () => {
    set((state) => ({ isOpen: false, modalData: {} }));
  },
}));

// alert용 모달 스토어
export const useAlertModalStore = create<ModalStore>((set) => ({
  isOpen: false,
  modalData: {} as ModalData,

  openModal: (modalData: ModalData) => {
    set((state) => ({ isOpen: true, modalData: { ...modalData } }));
  },

  closeModal: () => {
    set((state) => ({ isOpen: false, modalData: {} }));
  },
}));

````


### usage

1. 모달 컴포넌트를 생성합니다

<details>
<summary>모달 컴포넌트</summary>

```tsx
import { useModalStore } from './store/modal';
import styles from './Modal.module.scss';

const Modal = () => {

                                                                                     // 모달 스토어 사용
  const { isOpen, modalData, openModal, closeModal } = useModalStore();

      // 모달 컨텐츠, 취소 시 트리거 로직, submit시 트리거 로직
  const { children, onCancel, onSubmit } = modalData;

  if (!isOpen) {
    return <></>;
  }

  const onCancelInternal = () => {
    onCancel?.();
    closeModal();
  };

  const onSubmitInternal = () => {
    onSubmit?.();
    closeModal();
  };

  return (
    <div className={styles.modalContainer}> 
      <div className={styles.modalContent}> 
        <div style={{ color: 'red', cursor: 'pointer' }} onClick={closeModal}>
          x
        </div>
        <div>
          <div>{children}</div>
          <div>
            <button onClick={onCancelInternal}>cancel</button>
            <button onClick={onSubmitInternal}>submit</button>
          </div>
        </div>
      </div>
    </div>
  );
};

export default Modal;
```
</details>

2.  최상단 컴포넌트에 모달 컴포넌트 등록

<details>
<summary>최상단 컴포넌트</summary>

```tsx
// src\app\(afterlogin)\layout.tsx

import { Metadata } from 'next';

import RQProvider from './_components/RQProvider';
import { ReactChildrenProps } from '@/types/common';
import AlertModal from '../_components/_modules/AlertModal';
import ConfirmModal from '../_components/_modules/ConfirmModal';

export const metadata: Metadata = {
  title: '홈',
  description: 'HOME',
};

export default function AfterLoginLayout({ children }: ReactChildrenProps) {
  return (
    <div>
      <RQProvider>
        <div>{children}</div>

        <AlertModal />
        <ConfirmModal />

      </RQProvider>
    </div>
  );
}

```

</details>


3. 이후 각 모달을 사용하고자하는 컴포넌트에서 모달을 직접 호출해서 사용


<br/>
<br/>

> alert모달과 confirm모달에 따른 기본 레이아웃은 미리 지정해 두었습니다
- alert 
  화면 중앙에 위치, 추가 버튼 없음, 1초뒤에 자동으로 사라짐, 배경 클릭 가능

- confirm
  화면 중앙에 위치, 취소 확인 버튼, 모달창 유지, 흐릿한 배경, 배경 클릭 불가능


<br/>

### 📷 스크린 샷 (선택)

> 임시로 발표 작성 페이지에 alert모달을 적용해 봤습니다

![스크린샷 2024-01-25 231034](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/003b5287-46cd-4a22-b3ff-63780666b6f4)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 설명이 조금 부족하다 싶으시다면 [이 블로그](https://velog.io/@dev-redo/React-%EC%A0%84%EC%97%AD%EC%83%81%ED%83%9C%EA%B4%80%EB%A6%AC%EB%A5%BC-%ED%86%B5%ED%95%B4-%EB%AA%A8%EB%8B%AC%EC%9D%84-%EB%9D%84%EC%9A%B0%EB%8A%94-%EA%B2%8C%EC%8B%9C%EB%AC%BC%EC%9D%84-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B3%B4%EC%9E%90)  를 참조하시면 돼요!

- 원래 전역 모달은 최상단 컴포넌트에 선언하고 전역적으로 사용하는게 맞아서 로그인 이후 레이아웃인
`src\app\(afterlogin)\layout.tsx`에 선언해 두었습니다. 추후 개발하다가 옮기게 될 수도 있을 것 같아요

- alert창의 경우 자동으로 다시 사라지는걸 구현해야 되는데 css지식이 부족해서 그런가... 쉽지 않네요ㅠ 약간 깜빡이는(?)이슈가 있긴 합니다ㅠ


<br/>

### 🧪 테스트 범위 (선택)
