### PR TITLE
FlyoutMenu 컴포넌트 구현

### DIFF
--- a/src/app/(afterlogin)/element-test/page.tsx
+++ b/src/app/(afterlogin)/element-test/page.tsx
@@ -6,6 +6,7 @@ import Checkbox from '@/app/_components/_elements/Checkbox';
 import Radio from '@/app/_components/_elements/Radio';
 import TimePicker from '@/app/_components/_elements/TimePicker';
 import ToggleButton from '@/app/_components/_elements/ToggleButton';
+import FlyoutMenu from '@/app/_components/_modules/FlyoutMenu';
 
 export default function Page() {
   const [isAvailable, setIsAvailable] = useState(false);
@@ -80,6 +81,19 @@ export default function Page() {
           _onChangeSelected={handleOnChangeRadio}
         />
         <span>selected : {radioValue}</span>
+      </div>
+      <div>
+        <span>Flyout menu test</span>
+        <FlyoutMenu>
+          <FlyoutMenu.ToggleButton>
+            <div style={{ width: '50px', height: '50px', background: 'tomato' }}>click!</div>
+          </FlyoutMenu.ToggleButton>
+          <FlyoutMenu.MenuList>
+            <FlyoutMenu.MenuItem>apple</FlyoutMenu.MenuItem>
+            <FlyoutMenu.MenuItem>banana</FlyoutMenu.MenuItem>
+            <FlyoutMenu.MenuItem>cat</FlyoutMenu.MenuItem>
+          </FlyoutMenu.MenuList>
+        </FlyoutMenu>
       </div>
     </>
   );

--- a/src/app/_components/_modules/FlyoutMenu.module.scss
+++ b/src/app/_components/_modules/FlyoutMenu.module.scss
@@ -1,0 +1,8 @@
+.flyout {
+  &__menu {
+    background-color: #fff;
+    width: 100px;
+    height: 100px;
+    border: 1px solid #eee;
+  }
+}

--- a/src/app/_components/_modules/FlyoutMenu.tsx
+++ b/src/app/_components/_modules/FlyoutMenu.tsx
@@ -1,0 +1,30 @@
+import { ReactChildrenProps } from '@/types/common';
+import { useFlyoutStore } from '@/store/flyout';
+import Button from '../_elements/Button';
+import styles from './FlyoutMenu.module.scss';
+
+const FlyoutMenu = ({ children }: ReactChildrenProps) => {
+  return <div>{children}</div>;
+};
+
+const ToggleButton = ({ children }: ReactChildrenProps) => {
+  const { toggle } = useFlyoutStore();
+
+  return <Button _content={children} onClick={toggle} />;
+};
+
+const MenuList = ({ children }: ReactChildrenProps) => {
+  const { isOpen } = useFlyoutStore();
+
+  return isOpen && <ul className={styles.flyout__menu}>{children}</ul>;
+};
+
+const MenuItem = ({ children }: ReactChildrenProps) => {
+  return <li>{children}</li>;
+};
+
+FlyoutMenu.ToggleButton = ToggleButton;
+FlyoutMenu.MenuList = MenuList;
+FlyoutMenu.MenuItem = MenuItem;
+
+export default FlyoutMenu;

--- a/src/store/flyout.ts
+++ b/src/store/flyout.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface FlyOutStore {
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+export const useFlyoutStore = create<FlyOutStore>((set) => ({
+  isOpen: false,
+  toggle: () => {
+    set((state) => ({ isOpen: !state.isOpen }));
+  },
+}));

--- a/src/types/element.ts
+++ b/src/types/element.ts
@@ -4,7 +4,7 @@ import { ButtonHTMLAttributes, InputHTMLAttributes, LiHTMLAttributes, ReactNode 
 /** 버튼 컴포넌트 prop */
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** 버튼 내 자식 컴포넌트 */
-  _content: ReactNode;
+  _content: ReactNode; // TODO: 수정 논의 필요
   /** 버튼 스타일 */
   _className?: string;
 }
@@ -14,12 +14,15 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 /** 단일 리스트(li) 타입  */
 interface SingleList extends LiHTMLAttributes<HTMLLIElement> {
   /** li 내 자식 컴포넌트 */
-  _content: ReactNode;
+  _content: ReactNode; // TODO: 수정 논의 필요
   /** li 태그 스타일  */
   _className?: string;
 }
 
-/** ul안에 들어갈 li태그 배열 */
+/** ul안에 들어갈 li태그 배열
+ *
+ * TODO: 수정 논의 해봐요
+ */
 export type ListProps = SingleList[];
 // #endregion
 


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- 버튼 누르면 메뉴가 아래 뜨는 `FlyoutMenu` 컴포넌트를 개발했습니다.
>- 저희가 저번에 `ButtonList`라고 가제 지었던 UI가 저 이름이더라구요..!
- Compound Component 방식으로 구현했습니다.
>- 민호님이 모달 만들어주신 것처럼 zustand 써서 구현했어요.

<br/>

### 📷 스크린 샷 (선택)

1. _store > flyout.ts
>- zustand로 상태값과 set 함수를 선언했어요.
>- `isOpen` : 메뉴 리스트 노출 상태값 / `toggle` : 메뉴 리스트 토글 함수 (set)
<img width="633" alt="image" src="https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/61102301/0ea3da60-ab46-4680-baec-09e7e6319f51">  

<br/>
<br/>

2. _components > _modules > FlyoutMenu.tsx
>- `FlyoutMenu` : 컴포넌트의 전체 뼈대 / `ToggleButton` : 토글 버튼 / `MenuList` : 메뉴 리스트 / `MenuItem` : 메뉴 아이템
>- 페이지에서 FlyoutMenu 컴포넌트만 import 해서 쓸 수 있도록, FlyoutMenu의 속성값으로 버튼과 리스트 그리고 아이템을 넣었어요.
<img width="709" alt="image" src="https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/61102301/241859a6-7447-4ad1-ada6-dae21a49efeb">

<br/>
<br/>

3. (특정페이지) > _component > BlablaMenu.tsx
>- 아래 코드는 예시페이지에서 직접 `FlyoutMenu`를 가져와 사용했지만, 추후에는 페이지에서 사용하는 컴포넌트로 분리하고, 거기에 `FlyoutMenu`를 사용하면 돼요..!
<img width="809" alt="image" src="https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/61102301/5d2cabd0-2a24-4df1-8b5b-ff2e0beafc62">


<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 민호님 덕분에 Compound Component 구현 방식을 공부하고 직접 만들어볼 수 있어서 좋았어요. 🙌🙌🙌
- 민호님이 만들어주신 `Button`과 `List` 컴포넌트를 재사용하기 쉽게 변경했으면 해요.
>- 지금은 `_contents`로 내용을 받고 있는데, `children`을 허용하면 좀 더 편하지 않을까 싶습니다.
>- 이 부분은 저희 토요일에 만나서 한 번 이야기 나눠봐요!! :D

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
