### PR TITLE
textarea 공통 컴포넌트 적용

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -41,6 +41,7 @@
       "box-sizing",
       "white-space"
     ],
+    "scss/no-global-function-names": null,
     "selector-class-pattern": null,
     "selector-pseudo-class-no-unknown": [
       true,

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadMemo.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadMemo.tsx
@@ -5,6 +5,7 @@ import { ChangeEventHandler, Dispatch, SetStateAction, forwardRef } from 'react'
 import { PagesDataType } from '@/types/service';
 
 import styles from './UploadMemo.module.scss';
+import TextArea from '@/app/_components/_elements/TextArea';
 
 interface UploadMemoProps {
   memo: string | null;
@@ -32,8 +33,9 @@ const UploadMemo = forwardRef<HTMLInputElement, UploadMemoProps>(
       <div className={styles.container}>
         <p>메모 작성하기</p>
         <p className={styles.description}>발표하면서 계속 확인해야 하는 내용을 메모해보세요. </p>
-        <textarea
-          className={styles.memoInput}
+        <TextArea
+          // className={styles.memoInput}
+          theme="presentation_memo"
           value={memo || ''}
           onChange={onChange}
           placeholder="ex. 목소리 크기, 바른 자세 등에 관한 메모를 작성해주세요. "

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadMemo.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadMemo.tsx
@@ -34,8 +34,9 @@ const UploadMemo = forwardRef<HTMLInputElement, UploadMemoProps>(
         <p>메모 작성하기</p>
         <p className={styles.description}>발표하면서 계속 확인해야 하는 내용을 메모해보세요. </p>
         <TextArea
-          // className={styles.memoInput}
-          theme="presentation_memo"
+          size="size_md"
+          width="width_full"
+          theme="theme_gray"
           value={memo || ''}
           onChange={onChange}
           placeholder="ex. 목소리 크기, 바른 자세 등에 관한 메모를 작성해주세요. "

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadScript.module.scss
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadScript.module.scss
@@ -36,14 +36,14 @@
   padding-top: 30px;
   padding-bottom: 30px;
   background-color: $tmp-backgroud-color;
-}
 
-.warning {
-  &:focus {
-    outline: none;
+  &.warning {
+    &:focus {
+      outline: none;
+    }
+
+    border: 2px solid red;
   }
-
-  border: 2px solid red;
 }
 
 .lengthCount {

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadScript.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadScript.tsx
@@ -9,6 +9,7 @@ import styles from './UploadScript.module.scss';
 import { FieldErrors, RegisterOptions, UseFormRegister } from 'react-hook-form';
 
 import classNames from 'classnames/bind';
+import TextArea from '@/app/_components/_elements/TextArea';
 
 interface UploadScriptProps {
   script: string | null;
@@ -61,14 +62,14 @@ const UploadScript = forwardRef<HTMLInputElement, UploadScriptProps>(
           </small>
         )}
         <div className={styles.scriptSection}>
-          <textarea
+          <TextArea
             id="script"
             {...register('script', registerOptions)}
-            className={cx(['scriptTextarea', script && script?.length > 5000 && 'warning'])}
+            theme="presentation_script"
             value={script || ''}
             onChange={onChange}
             placeholder="가지고 있는 대본을 이곳에 복사하여 붙여 넣어주세요."
-          ></textarea>
+          ></TextArea>
           <span className={styles.lengthCount}>{script?.length}/5000</span>
         </div>
       </div>

--- a/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadScript.tsx
+++ b/src/app/(afterlogin)/presentation/upload/[id]/_component/UploadScript.tsx
@@ -65,7 +65,10 @@ const UploadScript = forwardRef<HTMLInputElement, UploadScriptProps>(
           <TextArea
             id="script"
             {...register('script', registerOptions)}
-            theme="presentation_script"
+            size="size_lg"
+            width="width_full"
+            theme="theme_gray"
+            warning={script!.length > 5000}
             value={script || ''}
             onChange={onChange}
             placeholder="가지고 있는 대본을 이곳에 복사하여 붙여 넣어주세요."

--- a/src/app/_components/_elements/TextArea.module.scss
+++ b/src/app/_components/_elements/TextArea.module.scss
@@ -1,35 +1,15 @@
-@import '@/app/_components/globals';
+@import '@/app/_components/mixins';
 
-.presentationTextArea {
-  width: 100%;
-  padding: 0 $text-area-padding-sm;
-  border: none;
-  font-size: $text-area-font-size-md;
-  border-radius: $text-area-border-radius-md;
+.scriptTextarea {
+  @include script-textarea;
 
-  &.scriptTextarea {
-    height: $text-area-height-lg;
-    padding-top: $text-area-padding-md;
-    padding-bottom: $text-area-padding-md;
-    font-size: $text-area-font-size-lg;
-    background-color: $tmp-backgroud-color;
-
-    &.warning {
-      &:focus {
-        outline: none;
-      }
-
-      border: $text-area-border-warn;
-    }
+  &.warning {
+    @include script-textarea-warning;
   }
+}
 
-  &.scriptMemo {
-    background-color: $tmp-backgroud-color;
-    padding-top: $text-area-padding-md;
-    padding-bottom: $text-area-padding-md;
-    height: $text-area-height-sm;
-    font-size: $text-area-font-size-lg;
-  }
+.scriptMemo {
+  @include script-memo;
 }
 
 // [data-theme='script']

--- a/src/app/_components/_elements/TextArea.module.scss
+++ b/src/app/_components/_elements/TextArea.module.scss
@@ -1,0 +1,35 @@
+@import '@/app/_components/globals';
+
+.presentationTextArea {
+  width: 100%;
+  padding: 0 $text-area-padding-sm;
+  border: none;
+  font-size: $text-area-font-size-md;
+  border-radius: $text-area-border-radius-md;
+
+  &.scriptTextarea {
+    height: $text-area-height-lg;
+    padding-top: $text-area-padding-md;
+    padding-bottom: $text-area-padding-md;
+    font-size: $text-area-font-size-lg;
+    background-color: $tmp-backgroud-color;
+
+    &.warning {
+      &:focus {
+        outline: none;
+      }
+
+      border: $text-area-border-warn;
+    }
+  }
+
+  &.scriptMemo {
+    background-color: $tmp-backgroud-color;
+    padding-top: $text-area-padding-md;
+    padding-bottom: $text-area-padding-md;
+    height: $text-area-height-sm;
+    font-size: $text-area-font-size-lg;
+  }
+}
+
+// [data-theme='script']

--- a/src/app/_components/_elements/TextArea.module.scss
+++ b/src/app/_components/_elements/TextArea.module.scss
@@ -1,15 +1,30 @@
 @import '@/app/_components/mixins';
 
-.scriptTextarea {
-  @include script-textarea;
+.textarea {
+  // 공통
+  border: none;
+
+  &.size_lg {
+    @include textarea-size($textarea-size-lg);
+  }
+
+  &.size_md {
+    @include textarea-size($textarea-size-md);
+  }
+
+  &.width_full {
+    @include textarea-width($textarea-width-full);
+  }
+
+  &.theme_gray {
+    @include textarea-theme($textarea-theme-gray);
+  }
 
   &.warning {
-    @include script-textarea-warning;
+    &:focus {
+      outline: none;
+    }
+
+    border: 2px solid red;
   }
 }
-
-.scriptMemo {
-  @include script-memo;
-}
-
-// [data-theme='script']

--- a/src/app/_components/_elements/TextArea.tsx
+++ b/src/app/_components/_elements/TextArea.tsx
@@ -6,16 +6,14 @@ import classNames from 'classnames';
 const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   ({ theme, value, ...rest }, ref) => {
     let themeClassName: string | undefined;
-
     if (theme === 'presentation_memo') {
-      themeClassName = `${classNames([styles.presentationTextArea, styles.scriptMemo])}`;
+      themeClassName = classNames(styles.scriptMemo);
     }
     if (theme === 'presentation_script') {
-      themeClassName = `${classNames([
-        styles.presentationTextArea,
-        styles.scriptTextarea,
-        (value as string[]).length > 5000 && styles.warning,
-      ])}`;
+      themeClassName = classNames({
+        [styles.scriptTextarea]: true,
+        [styles.warning]: (value as string[]).length > 5000,
+      });
     }
 
     return <textarea ref={ref} className={themeClassName} {...rest} />;

--- a/src/app/_components/_elements/TextArea.tsx
+++ b/src/app/_components/_elements/TextArea.tsx
@@ -1,0 +1,27 @@
+import { TextAreaProps } from '@/types/element';
+import { forwardRef } from 'react';
+import styles from './TextArea.module.scss';
+import classNames from 'classnames';
+
+const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ theme, value, ...rest }, ref) => {
+    let themeClassName: string | undefined;
+
+    if (theme === 'presentation_memo') {
+      themeClassName = `${classNames([styles.presentationTextArea, styles.scriptMemo])}`;
+    }
+    if (theme === 'presentation_script') {
+      themeClassName = `${classNames([
+        styles.presentationTextArea,
+        styles.scriptTextarea,
+        (value as string[]).length > 5000 && styles.warning,
+      ])}`;
+    }
+
+    return <textarea ref={ref} className={themeClassName} {...rest} />;
+  },
+);
+
+TextArea.displayName = 'TextArea';
+
+export default TextArea;

--- a/src/app/_components/_elements/TextArea.tsx
+++ b/src/app/_components/_elements/TextArea.tsx
@@ -1,22 +1,18 @@
 import { TextAreaProps } from '@/types/element';
 import { forwardRef } from 'react';
 import styles from './TextArea.module.scss';
-import classNames from 'classnames';
+import classNames from 'classnames/bind';
 
+const cx = classNames.bind(styles);
 const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ theme, value, ...rest }, ref) => {
-    let themeClassName: string | undefined;
-    if (theme === 'presentation_memo') {
-      themeClassName = classNames(styles.scriptMemo);
-    }
-    if (theme === 'presentation_script') {
-      themeClassName = classNames({
-        [styles.scriptTextarea]: true,
-        [styles.warning]: (value as string[]).length > 5000,
-      });
-    }
-
-    return <textarea ref={ref} className={themeClassName} {...rest} />;
+  ({ _className, size, width, theme, value, warning, ...rest }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cx(['textarea', `${size}`, `${width}`, `${theme}`, warning && 'warning'])}
+        {...rest}
+      />
+    );
   },
 );
 

--- a/src/app/_components/globals.scss
+++ b/src/app/_components/globals.scss
@@ -23,29 +23,37 @@
   border-radius: 15px;
 }
 
+$tmp-backgroud-color: #d7d7d7;
+
 // xs (extra small)
 // sm (small)
 // md (medium)
 // lg (large)
 // xl (extra large)
-
-$tmp-backgroud-color: #d5d5d5;
+// full (100%)
 
 /** # textarea */
-$text-area-font-size-lg: 1.1rem;
-$text-area-font-size-md: 0.9rem;
 
-// width
-$text-area-width: 100%;
+// 사이즈
+$textarea-size-md: (
+  height: 150px,
+  padding: 20px 20px,
+  font-size: 0.9rem,
+);
+$textarea-size-lg: (
+  height: 350px,
+  padding: 20px 30px,
+  font-size: 1.1rem,
+);
 
-// height
-$text-area-height-lg: 350px;
-$text-area-height-sm: 150px;
+// 너비
+$textarea-width-full: (
+  width: 100%,
+);
 
-// border
-$text-area-border-warn: 2px solid red;
-$text-area-border-radius-md: 15px;
-
-// padding
-$text-area-padding-md: 30px;
-$text-area-padding-sm: 20px;
+// 색상 테마
+$textarea-theme-gray: (
+  background-color: #d7d7d7,
+  color: black,
+  border-radius: 15px,
+);

--- a/src/app/_components/globals.scss
+++ b/src/app/_components/globals.scss
@@ -23,4 +23,29 @@
   border-radius: 15px;
 }
 
+// xs (extra small)
+// sm (small)
+// md (medium)
+// lg (large)
+// xl (extra large)
+
 $tmp-backgroud-color: #d5d5d5;
+
+// # textarea
+$text-area-font-size-lg: 1.1rem;
+$text-area-font-size-md: 0.9rem;
+
+// width
+$text-area-width: 100%;
+
+// height
+$text-area-height-lg: 350px;
+$text-area-height-sm: 150px;
+
+// border
+$text-area-border-warn: 2px solid red;
+$text-area-border-radius-md: 15px;
+
+// padding
+$text-area-padding-md: 30px;
+$text-area-padding-sm: 20px;

--- a/src/app/_components/globals.scss
+++ b/src/app/_components/globals.scss
@@ -31,7 +31,7 @@
 
 $tmp-backgroud-color: #d5d5d5;
 
-// # textarea
+/** # textarea */
 $text-area-font-size-lg: 1.1rem;
 $text-area-font-size-md: 0.9rem;
 

--- a/src/app/_components/mixins.scss
+++ b/src/app/_components/mixins.scss
@@ -1,0 +1,37 @@
+@import '@/app/_components/globals';
+
+/** # textarea */
+@mixin presentation-textArea {
+  width: 100%;
+  padding: 0 $text-area-padding-sm;
+  border: none;
+  font-size: $text-area-font-size-md;
+  border-radius: $text-area-border-radius-md;
+}
+@mixin script-textarea-warning {
+  &:focus {
+    outline: none;
+  }
+
+  border: $text-area-border-warn;
+}
+@mixin script-textarea {
+  @include presentation-textArea;
+
+  height: $text-area-height-lg;
+  padding-top: $text-area-padding-md;
+  padding-bottom: $text-area-padding-md;
+  font-size: $text-area-font-size-lg;
+  background-color: $tmp-backgroud-color;
+}
+
+@mixin script-memo {
+  @include presentation-textArea;
+  background-color: $tmp-backgroud-color;
+  padding-top: $text-area-padding-md;
+  padding-bottom: $text-area-padding-md;
+  height: $text-area-height-sm;
+  font-size: $text-area-font-size-lg;
+}
+
+/** # input */

--- a/src/app/_components/mixins.scss
+++ b/src/app/_components/mixins.scss
@@ -1,37 +1,18 @@
 @import '@/app/_components/globals';
 
 /** # textarea */
-@mixin presentation-textArea {
-  width: 100%;
-  padding: 0 $text-area-padding-sm;
-  border: none;
-  font-size: $text-area-font-size-md;
-  border-radius: $text-area-border-radius-md;
-}
-@mixin script-textarea-warning {
-  &:focus {
-    outline: none;
-  }
-
-  border: $text-area-border-warn;
-}
-@mixin script-textarea {
-  @include presentation-textArea;
-
-  height: $text-area-height-lg;
-  padding-top: $text-area-padding-md;
-  padding-bottom: $text-area-padding-md;
-  font-size: $text-area-font-size-lg;
-  background-color: $tmp-backgroud-color;
+@mixin textarea-size($size) {
+  height: map-get($size, height);
+  padding: map-get($size, padding);
+  font-size: map-get($size, font-size);
 }
 
-@mixin script-memo {
-  @include presentation-textArea;
-  background-color: $tmp-backgroud-color;
-  padding-top: $text-area-padding-md;
-  padding-bottom: $text-area-padding-md;
-  height: $text-area-height-sm;
-  font-size: $text-area-font-size-lg;
+@mixin textarea-width($width) {
+  width: map-get($width, width);
 }
 
-/** # input */
+@mixin textarea-theme($theme) {
+  background-color: map-get($theme, background-color);
+  color: map-get($theme, color);
+  border-radius: map-get($theme, border-radius);
+}

--- a/src/types/element.ts
+++ b/src/types/element.ts
@@ -1,4 +1,10 @@
-import { ButtonHTMLAttributes, InputHTMLAttributes, LiHTMLAttributes, ReactNode } from 'react';
+import {
+  ButtonHTMLAttributes,
+  InputHTMLAttributes,
+  LiHTMLAttributes,
+  ReactNode,
+  TextareaHTMLAttributes,
+} from 'react';
 
 // #region Button
 /** 버튼 컴포넌트 prop */
@@ -34,6 +40,12 @@ type InputValue = InputHTMLAttributes<HTMLInputElement>['value'];
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** 인풋 스타일 */
   _className?: string;
+}
+
+/** textarea 컴포넌트 prop */
+export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /** textarea 테마 */
+  theme?: 'presentation_memo' | 'presentation_script';
 }
 
 /** 체크박스 컴포넌트 prop */

--- a/src/types/element.ts
+++ b/src/types/element.ts
@@ -45,7 +45,12 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 /** textarea 컴포넌트 prop */
 export interface TextAreaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /** textarea 테마 */
-  theme?: 'presentation_memo' | 'presentation_script';
+  // theme?: 'presentation_memo' | 'presentation_script';
+  _className?: string;
+  size?: 'size_lg' | 'size_md';
+  width?: 'width_full';
+  theme?: 'theme_gray';
+  warning?: boolean;
 }
 
 /** 체크박스 컴포넌트 prop */


### PR DESCRIPTION
### 💁‍♂️ PR 개요

textarea 공통 컴포넌트를 구현합니다
어제 피드백 받은 대로, 세부적인 디자인의 props를 받아서 사용할 수 있도록 수정을 해 봤어요

<br >
<br >

## 구현

**1. textarea에 사용할 css요소들을 묶음으로 생성합니다**
   > 현재 width나 theme색상은 한가지로만 사용되고 있으므로 추가적인 선택지 없이 1개만 생성했습니다. 추후 다른 textarea가 사용된다면 이에 맞게 추가하겠습니다
   ![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/b89f4299-5f7d-48bf-bbae-78f638e2cb41)


**2. 위의 css요소들을 사용할 수 있는 믹스인을 설정합니다**
![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/7853273f-6504-4d41-ae1e-f3bb9bff4767)


**3. 실제 `<TextArea />` 컴포넌트에 사용할 스타일을 생성합니다. 2번에서 생성했던 믹스인을 호출합니다**
![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/9fa334bf-d57a-4a1d-8b62-05c112fe93f0)

<br >
<br >

## 사용하기 

**스타일은 위처럼 생성을 해 두고, 이제 textarea를 사용하는 곳에서 이에 맞는 props만 넘겨주면 됩니다**
![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/77797628-6cff-4133-82e3-248ae92c8036)

![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/8f0550a0-ce2f-4dbe-bd01-c011969547c8)


![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/ca8bcb49-deba-435f-932c-e7ea15c2825d)



<br/>

### 📷 스크린 샷 (선택)

2곳에 사용되는 textarea를 적용한 모습입니다
![image](https://github.com/DDD-Community/DDD-10-KKEUNKKEUN-WEB/assets/78631876/700ea328-8057-48b6-aa93-7feba14a16eb)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

- 최대한 styled-components에서 사용하는 공통 컴포넌트 스타일링 방식을 적용 해 봤습니다. 
  공통적으로 적용되는 스타일들은 묶어서 사용했고
  ```
  $textarea-size-md: (
  height: 150px,
  padding: 20px 20px,
  font-size: 0.9rem,
);
 ```
이걸 믹스인으로 사용하기 위해 `map-get` 으로 매핑했습니다

- 혹시 희주님이 생각하시는 방향성이 다르다면 얼마든지 바로 말해주세요! 반영해보겠습니다

<br/>

### 🧪 테스트 범위 (선택)

- 테스트 계획
- 테스트 완료 사항
