### PR TITLE
발표 목록 삭제 컴펌 노출하도록 로직 추가

### DIFF
--- a/src/app/(afterlogin)/home/_components/ExerciseItem.module.scss
+++ b/src/app/(afterlogin)/home/_components/ExerciseItem.module.scss
@@ -16,12 +16,13 @@
 }
 
 .menu {
-  li {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px 16px;
-  }
+  @include pure-button;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
 
   span {
     font-size: $font-2;

--- a/src/app/(afterlogin)/home/_components/ExerciseItem.tsx
+++ b/src/app/(afterlogin)/home/_components/ExerciseItem.tsx
@@ -1,43 +1,83 @@
-'use client';
-
 import FlyoutMenu from '@/app/_components/_modules/FlyoutMenu';
 import styles from './ExerciseItem.module.scss';
 import ExerciseInfo from './_elements/ExerciseInfo';
 import MenuIcon from './_svgs/MenuIcon';
 import ModifyIcon from './_svgs/ModifyIcon';
 import DeleteIcon from './_svgs/DeleteIcon';
+import useToggle from '@/app/_hooks/useToggle';
+import Confirm from '@/app/_components/_modules/_modal/Confirm';
 
-const ExerciseItem = () => {
+interface Props {
+  id: number;
+}
+
+const ExerciseItem = ({ id }: Props) => {
+  const flyout = useToggle();
+  const modal = useToggle();
+
+  const handleModify = () => {
+    // TODO: 발표 수정 페이지로 이동
+    console.log('modify');
+    flyout.onClose();
+  };
+
+  const handleDelete = () => {
+    flyout.onClose();
+    modal.onOpen();
+  };
+
+  const deleteItem = (id: number) => {
+    // TODO: 실제 API 연동 필요한 부분
+    console.log('delete: ', id);
+  };
+
   return (
-    <article className={styles.container}>
-      <div className={styles.thumbnail}>
-        <div className={styles.menu}>
-          <FlyoutMenu>
-            <FlyoutMenu.ToggleButton>
-              <MenuIcon />
-            </FlyoutMenu.ToggleButton>
-            <FlyoutMenu.MenuList>
-              <FlyoutMenu.MenuItem>
-                <ModifyIcon />
-                <span>수정</span>
-              </FlyoutMenu.MenuItem>
-              <FlyoutMenu.MenuItem>
-                <DeleteIcon />
-                <span>삭제</span>
-              </FlyoutMenu.MenuItem>
-            </FlyoutMenu.MenuList>
-          </FlyoutMenu>
+    <>
+      <article className={styles.container}>
+        <div className={styles.thumbnail}>
+          <div className={styles.menu__box}>
+            <FlyoutMenu context={flyout}>
+              <FlyoutMenu.ToggleButton>
+                <MenuIcon />
+              </FlyoutMenu.ToggleButton>
+              <FlyoutMenu.MenuList>
+                <FlyoutMenu.MenuItem>
+                  <button className={styles.menu} onClick={handleModify}>
+                    <ModifyIcon />
+                    <span>수정</span>
+                  </button>
+                </FlyoutMenu.MenuItem>
+                <FlyoutMenu.MenuItem>
+                  <button className={styles.menu} onClick={handleDelete}>
+                    <DeleteIcon />
+                    <span>삭제</span>
+                  </button>
+                </FlyoutMenu.MenuItem>
+              </FlyoutMenu.MenuList>
+            </FlyoutMenu>
+          </div>
         </div>
-      </div>
-      <div className={styles.info__box}>
-        <div className={styles.info}>
-          <ExerciseInfo />
+        <div className={styles.info__box}>
+          <div className={styles.info}>
+            <ExerciseInfo />
+          </div>
+          <div className={styles.action__box}>
+            <button className={styles.action}>연습하기</button>
+          </div>
         </div>
-        <div className={styles.action__box}>
-          <button className={styles.action}>연습하기</button>
-        </div>
-      </div>
-    </article>
+      </article>
+
+      <Confirm
+        context={modal}
+        title="발표 연습 파일을 삭제하시겠어요?"
+        message="삭제한 파일은 복원할 수 없습니다."
+        okayText="삭제하기"
+        cancelText="취소"
+        onOkayClick={() => {
+          deleteItem(id);
+        }}
+      />
+    </>
   );
 };
 

--- a/src/app/(afterlogin)/home/_components/ExerciseList.module.scss
+++ b/src/app/(afterlogin)/home/_components/ExerciseList.module.scss
@@ -3,6 +3,7 @@
 
 .container {
   width: 1440px;
+  margin-top: 32px;
 }
 
 .exercise {

--- a/src/app/(afterlogin)/home/_components/ExerciseList.tsx
+++ b/src/app/(afterlogin)/home/_components/ExerciseList.tsx
@@ -9,7 +9,8 @@ const ExerciseList = () => {
       <ul className={styles.exercise__box}>
         {Array.from({ length: 10 }, (_, i) => i).map((v, index) => (
           <li className={styles.exercise} key={index}>
-            <ExerciseItem />
+            {/* TODO: 실제 id 값으로 변경 */}
+            <ExerciseItem id={v} />
           </li>
         ))}
         <button className={styles.exercise__new}>

--- a/src/app/(afterlogin)/home/page.tsx
+++ b/src/app/(afterlogin)/home/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import ExerciseList from './_components/ExerciseList';
 import HistoryBanner from './_components/HistoryBanner';
 import styles from './page.module.scss';

--- a/src/app/_components/_modules/FlyoutMenu.tsx
+++ b/src/app/_components/_modules/FlyoutMenu.tsx
@@ -1,46 +1,66 @@
 import { ReactChildrenProps } from '@/types/common';
 import styles from './FlyoutMenu.module.scss';
-import { createContext, useContext, useState } from 'react';
+import { ReactNode, createContext, useContext, useEffect, useRef, useState } from 'react';
+import useToggle, { ToggleType } from '@/app/_hooks/useToggle';
+import useToggleContext, { ToggleContext } from '@/app/_hooks/useToggleContext';
+import ModalLayout from './_modal/ModalLayout';
 
-interface FlyoutContext {
-  open: boolean;
-  toggle: (value: boolean) => void;
+interface Props {
+  /** 컨텍스트 (부모에서 전달이 필요한 경우를 위해) */
+  context?: ToggleType;
+  /** 자식 노드 */
+  children: ReactNode;
 }
 
-const FlyoutContext = createContext<FlyoutContext | null>(null);
+const FlyoutMenu = ({ context, children }: Props) => {
+  const flyoutContext = context ?? useToggle();
+  const ref = useRef<HTMLDivElement>(null);
 
-const FlyoutMenu = ({ children }: ReactChildrenProps) => {
-  const [open, toggle] = useState(false);
+  useEffect(() => {
+    /** 모달 닫는 함수 선언 */
+    const closeModal = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node | null)) {
+        flyoutContext.onClose();
+      }
+    };
+
+    /** 이벤트 등록 */
+    window.addEventListener('mousedown', closeModal);
+    return () => {
+      window.addEventListener('mousedown', closeModal);
+    };
+  }, [flyoutContext]);
 
   return (
-    <FlyoutContext.Provider value={{ open, toggle }}>
-      <article className={styles.flyout}>{children}</article>
-    </FlyoutContext.Provider>
+    <ToggleContext.Provider value={flyoutContext}>
+      <article className={styles.flyout} ref={ref}>
+        {children}
+      </article>
+    </ToggleContext.Provider>
   );
 };
 
 const ToggleButton = ({ children }: ReactChildrenProps) => {
-  const context = useContext(FlyoutContext);
+  const context = useToggleContext();
 
-  if (!context) return;
-
-  const { open, toggle } = context;
+  const handleToggle = () => {
+    if (context.isOpen) context.onClose();
+    else context.onOpen();
+  };
 
   return (
-    <button className={styles.flyout__button} onClick={() => toggle(!open)}>
+    <button className={styles.flyout__button} onClick={handleToggle}>
       {children}
     </button>
   );
 };
 
 const MenuList = ({ children }: ReactChildrenProps) => {
-  const context = useContext(FlyoutContext);
+  const context = useToggleContext();
 
-  if (!context) return;
+  if (!context.isOpen) return null;
 
-  const { open } = context;
-
-  return open && <ul className={styles.flyout__list}>{children}</ul>;
+  return <ul className={styles.flyout__list}>{children}</ul>;
 };
 
 const MenuItem = ({ children }: ReactChildrenProps) => {


### PR DESCRIPTION
### 💁‍♂️ PR 개요

1. Flyout 컴포넌트 리팩토링
- useToggle 사용하도록
- useToggleContext 사용하도록
- 외부 영역 누르면 닫히도록

2. 발표 삭제 관련 로직 추가 (API 연동 필요)
- 아이템 삭제 시도 시, 컴펌 나오도록 로직 추가
- 컴펌에서 '삭제하기' 버튼 누를 시, 삭제 로직 동작하도록 추가 (실제 API 연동 필요)

<br/>

### 🗣 리뷰어한테 할 말 (선택)

- `<Comfirm />`을 `<ExerciseItem />` 컴포넌트에서 호출하도록 했는데, 뭔가 모달을 작은 컴포넌트에서 호출하는 게 맞는지 약간의 찝찝함이 있습니다.
>- Page에 Confirm을 두고 prop drilling과 event로 처리하려고 했는데, 그것보다는 지금 방식이 전달할 것이 적어 더 효율적이라 생각했습니다.
>- 근데 모달이 페이지랑 같은 레벨처럼 느껴져서 약간 찝찝하네요.. 민호님 생각은 어떠신가요 !?

<br/>
