### PR TITLE
날짜 오류 수정

### DIFF
--- a/src/app/(afterlogin)/upload/[id]/_component/UploadDeadlineDate.tsx
+++ b/src/app/(afterlogin)/upload/[id]/_component/UploadDeadlineDate.tsx
@@ -33,11 +33,16 @@ const UploadDeadlineDate = forwardRef<HTMLInputElement, UploadDeadlineDateProps>
 
     // 리액트 캘린더 전용 업데이트 함수
     const setDate: Dispatch<SetStateAction<Value>> = (newValue) => {
+      // KST를 UTC로 변환하기 위해, getTimezoneOffset()의 결과를 반전시키고 9시간(한국 시간대)을 더함
+      const targetDate = newValue as Date;
+      const utcDate = new Date(
+        targetDate.getTime() - targetDate.getTimezoneOffset() * 60000 + 9 * 60 * 60000,
+      );
+
       setPresentationData((prev) => {
         const shallow = { ...prev };
         shallow.title = getValues('title');
-        shallow.deadlineDate =
-          newValue instanceof Function ? newValue(prev.deadlineDate) : newValue;
+        shallow.deadlineDate = newValue instanceof Function ? newValue(prev.deadlineDate) : utcDate;
         const shallowSlides = [...shallow.slides];
         shallowSlides[currentPageIndex] = {
           ...shallowSlides[currentPageIndex],

--- a/src/app/(afterlogin)/upload/[id]/_component/UploadDeadlineDate.tsx
+++ b/src/app/(afterlogin)/upload/[id]/_component/UploadDeadlineDate.tsx
@@ -34,6 +34,7 @@ const UploadDeadlineDate = forwardRef<HTMLInputElement, UploadDeadlineDateProps>
     // 리액트 캘린더 전용 업데이트 함수
     const setDate: Dispatch<SetStateAction<Value>> = (newValue) => {
       // KST를 UTC로 변환하기 위해, getTimezoneOffset()의 결과를 반전시키고 9시간(한국 시간대)을 더함
+      // (년,월,일만 적용)
       const targetDate = newValue as Date;
       const utcDate = new Date(
         targetDate.getTime() - targetDate.getTimezoneOffset() * 60000 + 9 * 60 * 60000,


### PR DESCRIPTION
### 💁‍♂️ PR 개요

클라이언트에서 선택한 날짜를 post하게 되면 선택한 날짜보다 하루 전의 날짜가 전송되는 문제가 있었습니다.

> chat gpt 답변입니다

이 현상은 시간대 차이와 날짜를 처리하는 방식 때문에 발생합니다. Date 객체를 JSON.stringify()로 변환할 때, JavaScript는 Date 객체를 UTC (협정 세계시)로 변환하여 문자열로 바꾸게 됩니다. 이 과정에서 당신의 로컬 시간대인 한국 표준시(KST, GMT+9)가 UTC로 변환되면서 시간 차이가 반영됩니다.
한국은 UTC보다 9시간이 빠르기 때문에, 한국 시간으로 2024년 3월 26일 자정을 UTC로 변환하면, UTC 기준으로는 2024년 3월 25일 15시가 됩니다. 


<br/>

### 📷 스크린 샷 (선택)



<br/>

### 🗣 리뷰어한테 할 말 (선택)



<br/>

### 🧪 테스트 범위 (선택)

