### PR TITLE
QA 이슈 대응 - #62 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-calendar": "^4.8.0",
         "react-dom": "^18",
         "react-hook-form": "^7.49.3",
+        "react-icons": "^5.2.1",
         "react-intersection-observer": "^9.8.1",
         "react-qr-code": "^2.0.12",
         "zustand": "^4.4.7"
@@ -1628,9 +1629,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001570",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
-      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+      "version": "1.0.30001629",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+      "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5405,6 +5406,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-intersection-observer": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-calendar": "^4.8.0",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",
+    "react-icons": "^5.2.1",
     "react-intersection-observer": "^9.8.1",
     "react-qr-code": "^2.0.12",
     "zustand": "^4.4.7"

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardItem.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardItem.module.scss
@@ -7,11 +7,12 @@
 }
 
 .thumbnail {
+  overflow: hidden;
   position: relative;
   width: 100%;
   height: 250px;
-  margin-bottom: 12px;
   border: 1px solid $gray-1;
+  margin-bottom: 12px;
   border-radius: 16px;
 }
 

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardItem.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardItem.module.scss
@@ -7,7 +7,6 @@
 }
 
 .thumbnail {
-  overflow: hidden;
   position: relative;
   width: 100%;
   height: 250px;

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardItem.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardItem.tsx
@@ -17,6 +17,8 @@ import PracticeButton from './_Home/PracticeButton';
 import FeedbackScoreButton from './_Feedback/FeedbackScoreButton';
 import { FeedbackListTypeGuard, PresentationListTypeGuard } from '@/types/guards';
 import { CDN_BASE_URL } from '@/config/path';
+import { ReactNode } from 'react';
+import FailFeedback from './_Feedback/FailFeedback';
 
 interface Props {
   listInfo: CardListType;
@@ -41,27 +43,48 @@ const CardItem = ({ listInfo }: Props) => {
     modal.onOpen();
   };
 
-  const deleteItem = () => {
-    presentationListMutate();
+  const getThumbnailImg = (): ReactNode => {
+    if (PresentationListTypeGuard(listInfo)) {
+      return listInfo.thumbnailPath ? (
+        <Image
+          src={`${CDN_BASE_URL}/${listInfo.thumbnailPath}`}
+          alt={`${listInfo.id} 썸네일`}
+          width={440}
+          height={250}
+          style={{ borderRadius: '16px' }}
+        />
+      ) : (
+        <div className={styles.dummyImg} />
+      );
+    }
+    if (FeedbackListTypeGuard(listInfo)) {
+      if (listInfo.status === 'FAIL') {
+        return <FailFeedback />;
+      }
+      if (
+        (listInfo.status === 'DONE' || listInfo.status === 'IN_PROGRESS') &&
+        listInfo.thumbnailPath
+      ) {
+        return (
+          <Image
+            src={`${CDN_BASE_URL}/${listInfo.thumbnailPath}`}
+            alt={`${listInfo.id} 썸네일`}
+            width={440}
+            height={250}
+            style={{ borderRadius: '16px' }}
+          />
+        );
+      } else {
+        return <div className={styles.dummyImg} />;
+      }
+    }
   };
-
-  const thumbnailImage = listInfo.thumbnailPath ? (
-    <Image
-      src={`${CDN_BASE_URL}/${listInfo.thumbnailPath}`}
-      alt={`${listInfo.id} 썸네일`}
-      width={440}
-      height={250}
-      style={{ borderRadius: '16px' }}
-    />
-  ) : (
-    <div className={styles.dummyImg} />
-  );
 
   return (
     <>
       <article className={styles.container}>
         <div className={styles.thumbnail}>
-          {thumbnailImage}
+          {getThumbnailImg()}
           <div className={styles.menu__box}>
             {usage === 'home' && (
               <FlyoutMenu context={flyout}>
@@ -110,7 +133,7 @@ const CardItem = ({ listInfo }: Props) => {
         okayText="삭제하기"
         cancelText="취소"
         onOkayClick={() => {
-          deleteItem();
+          presentationListMutate();
         }}
       />
     </>

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
@@ -73,14 +73,15 @@ const CardList = () => {
         statusInfo.push(...row);
       });
 
-      if (statusInfo.filter((i) => i !== 'FAIL').some((i) => i === 'IN_PROGRESS')) {
+      const shouldRefetch = statusInfo.some((status) => status === 'IN_PROGRESS');
+      if (shouldRefetch) {
         refetchInterval = setInterval(() => {
           refetch();
         }, 1000);
       }
     }
     return () => {
-      clearInterval(refetchInterval);
+      if (refetchInterval) clearInterval(refetchInterval);
     };
   }, [data, refetch, usage]);
 

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
@@ -10,13 +10,15 @@ import PlusIcon from '../home/_components/_svgs/PlusIcon';
 import CardItem from './CardItem';
 import { clientFeedbackApi } from '@/services/client/feedback';
 
+type StatusArrType = FeedbackListType['page']['content'][0]['status'][];
+
 const CardList = () => {
   // 피드백의 경우, 완료가 안 된게 있으면 1초마다 fetch
   const router = useRouter();
   const pathname = usePathname();
   const usage: 'feedback' | 'home' = pathname === `/feedback/list` ? 'feedback' : 'home';
 
-  const { data, fetchNextPage, hasNextPage, isFetching, refetch } = useInfiniteQuery({
+  let { data, fetchNextPage, hasNextPage, isFetching, refetch } = useInfiniteQuery({
     queryKey: [usage, 'list'],
     queryFn: async ({ pageParam = 0 }) => {
       if (usage === 'home') {
@@ -51,10 +53,37 @@ const CardList = () => {
   });
 
   useEffect(() => {
-    if (inView) {
+    // if (inView) {
+    //   !isFetching && hasNextPage && fetchNextPage();
+    // }
+    if (usage === 'feedback') {
       !isFetching && hasNextPage && fetchNextPage();
     }
-  }, [inView, isFetching, hasNextPage, fetchNextPage]);
+    if (usage === 'home' && inView) {
+      !isFetching && hasNextPage && fetchNextPage();
+    }
+  }, [inView, isFetching, hasNextPage, fetchNextPage, usage]);
+
+  useEffect(() => {
+    let refetchInterval: NodeJS.Timeout | undefined;
+    if (data !== undefined && usage === 'feedback') {
+      const statusInfo: StatusArrType = [];
+      data?.pages.forEach((i) => {
+        const row = i.page.content.map((i: FeedbackListType['page']['content'][0]) => i.status);
+        statusInfo.push(...row);
+      });
+      // console.log(statusInfo);
+      // // ['DONE', 'DONE', 'DONE', 'DONE']
+      if (statusInfo.filter((i) => i !== 'FAIL').some((i) => i === 'IN_PROGRESS')) {
+        refetchInterval = setInterval(() => {
+          refetch();
+        }, 1000);
+      }
+    }
+    return () => {
+      clearInterval(refetchInterval);
+    };
+  }, [data, refetch, usage]);
 
   return (
     <section className={styles.container}>
@@ -82,8 +111,7 @@ const CardList = () => {
           <span>새 발표 추가하기</span>
         </button>
       </ul>
-
-      <div ref={ref} style={{ height: '30px' }} />
+      {usage === 'home' && <div ref={ref} style={{ height: '30px' }} />}
     </section>
   );
 };

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
@@ -18,7 +18,7 @@ const CardList = () => {
   const pathname = usePathname();
   const usage: 'feedback' | 'home' = pathname === `/feedback/list` ? 'feedback' : 'home';
 
-  let { data, fetchNextPage, hasNextPage, isFetching, refetch } = useInfiniteQuery({
+  const { data, fetchNextPage, hasNextPage, isFetching, refetch } = useInfiniteQuery({
     queryKey: [usage, 'list'],
     queryFn: async ({ pageParam = 0 }) => {
       if (usage === 'home') {

--- a/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/CardList.tsx
@@ -72,8 +72,7 @@ const CardList = () => {
         const row = i.page.content.map((i: FeedbackListType['page']['content'][0]) => i.status);
         statusInfo.push(...row);
       });
-      // console.log(statusInfo);
-      // // ['DONE', 'DONE', 'DONE', 'DONE']
+
       if (statusInfo.filter((i) => i !== 'FAIL').some((i) => i === 'IN_PROGRESS')) {
         refetchInterval = setInterval(() => {
           refetch();

--- a/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/EmptyFeedback.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/EmptyFeedback.module.scss
@@ -1,0 +1,24 @@
+@import '@/styles/globals';
+@import '@/styles/mixins';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-width: 1440px;
+  width: 100dvw;
+  height: calc(100dvh - 68px);
+
+  p {
+    font-size: $font-1;
+  }
+
+  a {
+    margin: 20px;
+
+    @include button_size_web;
+    @include button_theme_default;
+  }
+}

--- a/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/EmptyFeedback.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/EmptyFeedback.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styles from './EmptyFeedback.module.scss';
+import Link from 'next/link';
+
+const EmptyFeedback = () => {
+  return (
+    <div className={styles.container}>
+      <p>아직 연습할 발표가 없네요!</p>
+      <p>완성도 있는 발표를 위해 연습을 시작해볼까요?</p>
+      <Link href={'/upload/new'}>발표 연습 시작하기</Link>
+    </div>
+  );
+};
+
+export default EmptyFeedback;

--- a/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FailFeedback.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FailFeedback.module.scss
@@ -1,0 +1,13 @@
+@import '@/styles/globals';
+@import '@/styles/mixins';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  background-color: $gray-0;
+  width: 100%;
+  height: 100%;
+  gap: 20px;
+}

--- a/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FailFeedback.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FailFeedback.module.scss
@@ -10,4 +10,5 @@
   width: 100%;
   height: 100%;
   gap: 20px;
+  border-radius: 16px;
 }

--- a/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FailFeedback.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FailFeedback.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from './FailFeedback.module.scss';
+import { IoIosWarning } from 'react-icons/io';
+const FailFeedback = () => {
+  return (
+    <div className={styles.container}>
+      <IoIosWarning size={60} />
+      <h3>피드백 데이터 생성에 실패했습니다.</h3>
+    </div>
+  );
+};
+
+export default FailFeedback;

--- a/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FeedbackScoreButton.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/_components/_Feedback/FeedbackScoreButton.tsx
@@ -9,16 +9,26 @@ interface Props {
 }
 
 const FeedbackScoreButton = ({ status, score, onClick }: Props) => {
+  const getFeedBackScore = () => {
+    if (status === 'DONE') {
+      return `${score}점`;
+    }
+    if (status === 'IN_PROGRESS') {
+      return `채점중`;
+    }
+  };
   return (
     <div className={styles.action__box}>
-      <button
-        className={styles.action}
-        onClick={() => {
-          status === 'DONE' && onClick();
-        }}
-      >
-        {status === 'DONE' ? `${score}점` : '채점중'}
-      </button>
+      {status !== 'FAIL' && (
+        <button
+          className={styles.action}
+          onClick={() => {
+            status === 'DONE' && onClick();
+          }}
+        >
+          {getFeedBackScore()}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/app/(afterlogin)/(common_navbar)/feedback/list/page.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/feedback/list/page.tsx
@@ -7,7 +7,7 @@ import CardList from '../../_components/CardList';
 export default async function Page() {
   const queryClient = new QueryClient();
   const listResponse = await queryClient.fetchInfiniteQuery({
-    queryKey: ['home', 'list'],
+    queryKey: ['feedback', 'list'],
     queryFn: async ({ pageParam = 0 }) => {
       const response = await serverFeedbackApi.getFeedbackList({ pageParam });
       return await response.json();

--- a/src/app/(afterlogin)/(common_navbar)/feedback/list/page.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/feedback/list/page.tsx
@@ -3,6 +3,7 @@ import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query
 import React from 'react';
 import styles from './page.module.scss';
 import CardList from '../../_components/CardList';
+import EmptyFeedback from '../../_components/_Feedback/EmptyFeedback';
 
 export default async function Page() {
   const queryClient = new QueryClient();
@@ -22,7 +23,7 @@ export default async function Page() {
   return (
     <>
       {isEmpty ? (
-        <>empty</>
+        <EmptyFeedback />
       ) : (
         <div className={styles.container}>
           <HydrationBoundary state={dehydratedState}>

--- a/src/app/(afterlogin)/(common_navbar)/home/_hooks/presentationList.ts
+++ b/src/app/(afterlogin)/(common_navbar)/home/_hooks/presentationList.ts
@@ -16,6 +16,7 @@ export const useGetLatestPresentation = () => {
 
 export const useDeletePresentation = (id: number) => {
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const response = useMutation({
     mutationKey: ['delete', id],
@@ -24,6 +25,8 @@ export const useDeletePresentation = (id: number) => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['home', 'list'] });
+      queryClient.invalidateQueries({ queryKey: ['home', 'latest'] });
+      router.refresh();
     },
     onError: (error) => {
       alert(error.message);

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/ControlButtons.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/ControlButtons.tsx
@@ -162,7 +162,7 @@ const ControlButtons = ({
                             src={`${CDN_BASE_URL}/${item.imageFilePath}`}
                             fill
                             alt="ppt이미지"
-                            style={{ objectFit: 'contain', borderRadius: '8px' }}
+                            style={{ borderRadius: '8px' }}
                           />
                           <button onClick={(e) => remove(e, index)} className={styles.closeButton}>
                             <PptImageSvgs>

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/ControlButtons.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/ControlButtons.tsx
@@ -97,6 +97,11 @@ const ControlButtons = ({
     setPresentationData((prev) => {
       const shallow = { ...prev };
       shallow.title = getValues('title');
+      shallow.timeLimit.hours = Number(getValues('timeLimit_hour'));
+      shallow.timeLimit.minutes = Number(getValues('timeLimit_minute'));
+      shallow.alertTime.hours = Number(getValues('alertTime_hour'));
+      shallow.alertTime.minutes = Number(getValues('alertTime_minute'));
+
       const shallowSlides = [...shallow.slides];
       shallowSlides[currentPageIndex] = {
         ...shallowSlides[currentPageIndex],
@@ -122,6 +127,11 @@ const ControlButtons = ({
     setPresentationData((prev) => {
       const shallow = { ...prev };
       shallow.title = getValues('title');
+      shallow.timeLimit.hours = Number(getValues('timeLimit_hour'));
+      shallow.timeLimit.minutes = Number(getValues('timeLimit_minute'));
+      shallow.alertTime.hours = Number(getValues('alertTime_hour'));
+      shallow.alertTime.minutes = Number(getValues('alertTime_minute'));
+
       const shallowSlides = [...shallow.slides];
       shallowSlides[currentPageIndex] = {
         ...shallowSlides[currentPageIndex],

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/CreatePresentation.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/CreatePresentation.tsx
@@ -12,7 +12,7 @@ const CreatePresentation = () => {
     deadlineDate: null,
     timeLimit: {
       hours: null,
-      minutes: 1,
+      minutes: null,
     },
     alertTime: {
       hours: null,

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/InputSection.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/InputSection.tsx
@@ -177,29 +177,39 @@ const InputSection = ({
           <form
             onSubmit={handleSubmit(async (data) => {
               // 1. 마지막 더미 페이지 제거
-              const shallow = { ...presentationData };
-              const shallowSlides = [...presentationData.slides.slice(0, -1)];
 
-              // 2. 현재페이지의 title,script,memo를 getValue로 가져온 뒤 상태에 추가
+              const shallow = { ...presentationData };
+
+              const shallowSlides = [...shallow.slides.slice(0, -1)];
+
+              let presentationUploadInfo;
               shallow.title = data.title;
-              shallowSlides[currentPageIndex] = {
-                ...shallowSlides[currentPageIndex],
-                script: data.script,
-                memo: data.memo,
-              };
-              const result = {
-                ...shallow,
-                slides: shallowSlides,
-              };
+              if (currentPageIndex !== presentationData.slides.length - 1) {
+                // 2. 현재페이지의 title,script,memo를 getValue로 가져온 뒤 상태에 추가
+                shallowSlides[currentPageIndex] = {
+                  ...shallowSlides[currentPageIndex],
+                  script: data.script,
+                  memo: data.memo,
+                };
+                presentationUploadInfo = {
+                  ...shallow,
+                  slides: shallowSlides,
+                };
+              } else {
+                presentationUploadInfo = {
+                  ...shallow,
+                  slides: shallowSlides,
+                };
+              }
 
               // 3. post, patch + mutation의 onSuccess로 모달 띄우기
               if (slug === 'new') {
                 // post
-                postMutation.mutate(result);
+                postMutation.mutate(presentationUploadInfo);
               }
               if (slug !== 'new') {
                 // patch
-                patchMutation.mutate(result);
+                patchMutation.mutate(presentationUploadInfo);
               }
             })}
           >

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/InputSection.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/InputSection.tsx
@@ -80,6 +80,10 @@ const InputSection = ({
         script: presentationData.slides[currentPageIndex].script || '',
         memo: presentationData.slides[currentPageIndex].memo || '',
         deadlineDate: presentationData.deadlineDate,
+        timeLimit_hour: presentationData.timeLimit.hours || 0,
+        timeLimit_minute: presentationData.timeLimit.minutes || 0,
+        alertTime_hour: presentationData.alertTime.hours || 0,
+        alertTime_minute: presentationData.alertTime.minutes || 0,
       });
     };
     resetFormData();
@@ -179,11 +183,18 @@ const InputSection = ({
               // 1. 마지막 더미 페이지 제거
 
               const shallow = { ...presentationData };
+              console.log(shallow);
 
               const shallowSlides = [...shallow.slides.slice(0, -1)];
 
-              let presentationUploadInfo;
               shallow.title = data.title;
+              shallow.timeLimit.hours = data.timeLimit_hour;
+              shallow.timeLimit.minutes = data.timeLimit_minute;
+              shallow.alertTime.hours = data.alertTime_hour;
+              shallow.alertTime.minutes = data.alertTime_minute;
+
+              let presentationUploadInfo;
+
               if (currentPageIndex !== presentationData.slides.length - 1) {
                 // 2. 현재페이지의 title,script,memo를 getValue로 가져온 뒤 상태에 추가
                 shallowSlides[currentPageIndex] = {
@@ -253,6 +264,9 @@ const InputSection = ({
               setPresentationData={setPresentationData}
               currentPageIndex={currentPageIndex}
               getValues={getValues}
+              setValue={setValue}
+              register={register}
+              errors={errors}
             />
             <div className={styles.saveButtons}>
               <button

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/InputSection.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/InputSection.tsx
@@ -183,7 +183,6 @@ const InputSection = ({
               // 1. 마지막 더미 페이지 제거
 
               const shallow = { ...presentationData };
-              console.log(shallow);
 
               const shallowSlides = [...shallow.slides.slice(0, -1)];
 
@@ -259,10 +258,6 @@ const InputSection = ({
               getValues={getValues}
             />
             <UploadTimer
-              timeLimit={presentationData.timeLimit}
-              alertTime={presentationData.alertTime}
-              setPresentationData={setPresentationData}
-              currentPageIndex={currentPageIndex}
               getValues={getValues}
               setValue={setValue}
               register={register}

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadDeadlineDate.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadDeadlineDate.tsx
@@ -43,6 +43,11 @@ const UploadDeadlineDate = forwardRef<HTMLInputElement, UploadDeadlineDateProps>
       setPresentationData((prev) => {
         const shallow = { ...prev };
         shallow.title = getValues('title');
+        shallow.timeLimit.hours = Number(getValues('timeLimit_hour'));
+        shallow.timeLimit.minutes = Number(getValues('timeLimit_minute'));
+        shallow.alertTime.hours = Number(getValues('alertTime_hour'));
+        shallow.alertTime.minutes = Number(getValues('alertTime_minute'));
+
         shallow.deadlineDate = newValue instanceof Function ? newValue(prev.deadlineDate) : utcDate;
         const shallowSlides = [...shallow.slides];
         shallowSlides[currentPageIndex] = {

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadPpt.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadPpt.module.scss
@@ -11,7 +11,7 @@
   @include flex-center;
 
   position: relative;
-  width: 100%;
+  width: 100%; // .leftSection 전체 너비 사용
   height: 285px;
   border: 1px solid $gray-3;
   border-radius: 16px;
@@ -57,6 +57,10 @@
 }
 
 .hoverSection {
+  position: relative;
+  width: 100%;
+  height: 100%;
+
   &:hover {
     .changePptImageButton {
       display: block;

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadPpt.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadPpt.tsx
@@ -45,6 +45,11 @@ const UploadPpt = ({
         setPresentationData((prev) => {
           const shallow = { ...prev };
           shallow.title = getValues('title');
+          shallow.timeLimit.hours = Number(getValues('timeLimit_hour'));
+          shallow.timeLimit.minutes = Number(getValues('timeLimit_minute'));
+          shallow.alertTime.hours = Number(getValues('alertTime_hour'));
+          shallow.alertTime.minutes = Number(getValues('alertTime_minute'));
+
           const shallowSlides = [...shallow.slides];
           shallowSlides[currentPageIndex] = {
             ...shallowSlides[currentPageIndex],
@@ -80,6 +85,11 @@ const UploadPpt = ({
     setPresentationData((prev) => {
       const shallow = { ...prev };
       shallow.title = getValues('title');
+      shallow.timeLimit.hours = Number(getValues('timeLimit_hour'));
+      shallow.timeLimit.minutes = Number(getValues('timeLimit_minute'));
+      shallow.alertTime.hours = Number(getValues('alertTime_hour'));
+      shallow.alertTime.minutes = Number(getValues('alertTime_minute'));
+
       const shallowSlides = [...shallow.slides];
       shallowSlides[currentPageIndex] = {
         ...shallowSlides[currentPageIndex],

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadPpt.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadPpt.tsx
@@ -120,10 +120,8 @@ const UploadPpt = ({
               <Image
                 src={`${CDN_BASE_URL}/${pptInfo.imageFilePath}`}
                 alt={`${currentPageIndex + 1}페이지 ppt 이미지`}
-                width={503}
-                height={283}
-                // fill
-                style={{ objectFit: 'contain', borderRadius: '16px' }}
+                fill
+                style={{ borderRadius: '16px' }}
                 className={styles.pptImage}
               />
               <button className={styles.changePptImageButton} onClick={onClickButton}>

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadTimer.module.scss
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadTimer.module.scss
@@ -60,5 +60,6 @@
 
 .alarmWaring {
   color: $red-7;
+  font-weight: bolder;
   margin-right: 10px;
 }

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadTimer.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_component/UploadTimer.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { ChangeEventHandler, Dispatch, SetStateAction, forwardRef, useState } from 'react';
+import { ChangeEventHandler, forwardRef } from 'react';
 
-import { UploadDataType, ValidtaionType } from '@/types/service';
+import { ValidtaionType } from '@/types/service';
 
 import styles from './UploadTimer.module.scss';
 import InputFormSvgs from '../_svgs/InputFormSvgs';
@@ -15,10 +15,6 @@ import {
 } from 'react-hook-form';
 
 interface UploadTimerProps {
-  timeLimit: UploadDataType['timeLimit'];
-  alertTime: UploadDataType['alertTime'];
-  setPresentationData: Dispatch<SetStateAction<UploadDataType>>;
-  currentPageIndex: number;
   getValues: UseFormGetValues<ValidtaionType>;
   setValue: UseFormSetValue<ValidtaionType>;
   register: UseFormRegister<ValidtaionType>;
@@ -26,19 +22,7 @@ interface UploadTimerProps {
 }
 
 const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
-  (
-    {
-      timeLimit,
-      alertTime,
-      setPresentationData,
-      currentPageIndex,
-      getValues,
-      setValue,
-      register,
-      errors,
-    },
-    ref,
-  ) => {
+  ({ getValues, setValue, register, errors }, ref) => {
     const validateAlertTime = () => {
       const { timeLimit_hour, timeLimit_minute, alertTime_hour, alertTime_minute } = getValues();
 
@@ -83,51 +67,6 @@ const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
         setValue('alertTime_minute', convertedMinute);
       }
     };
-    const onChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-      let { name, value } = e.target;
-      let changeValue = Number(value);
-
-      setPresentationData((prev) => {
-        const shallow = { ...prev };
-        const timeLimitShallow = { ...shallow.timeLimit };
-        const alertTimeShallow = { ...shallow.alertTime };
-
-        if (name === 'timeLimit_hour') {
-          if (changeValue > 12) changeValue = 12;
-          timeLimitShallow['hours'] = changeValue;
-        }
-
-        if (name === 'timeLimit_minute') {
-          if (changeValue > 59) changeValue = 59;
-          timeLimitShallow['minutes'] = changeValue;
-        }
-
-        if (name === 'alertTime_hour') {
-          if (changeValue > 12) changeValue = 12;
-          alertTimeShallow['hours'] = changeValue;
-        }
-
-        if (name === 'alertTime_minute') {
-          if (changeValue > 59) changeValue = 59;
-          alertTimeShallow['minutes'] = changeValue;
-        }
-
-        shallow.title = getValues('title');
-        shallow.timeLimit = timeLimitShallow;
-        shallow.alertTime = alertTimeShallow;
-
-        const shallowSlides = [...shallow.slides];
-        shallowSlides[currentPageIndex] = {
-          ...shallowSlides[currentPageIndex],
-          script: getValues('script'),
-          memo: getValues('memo'),
-        };
-        return {
-          ...shallow,
-          slides: shallowSlides,
-        };
-      });
-    };
 
     return (
       <div className={styles.container}>
@@ -138,13 +77,13 @@ const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
           </label>
           <div className={styles.timerInput}>
             {errors.timeLimit_minute && (
-              <p className={styles.alarmWaring}>{errors.timeLimit_minute?.message}</p>
+              <p className={styles.alarmWaring} role="alert">
+                {errors.timeLimit_minute?.message}
+              </p>
             )}
             <input
               type="number"
               id="timer"
-              // onChange={onChange}
-              // value={timeLimit.hours ? timeLimit.hours : 0}
               {...register('timeLimit_hour', {
                 ...registerOptionsForTimeLimit,
                 onChange: onHourInputChange,
@@ -156,12 +95,10 @@ const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
             <input
               type="number"
               id="timer"
-              // value={timeLimit.minutes ? timeLimit.minutes : 0}
               {...register('timeLimit_minute', {
                 ...registerOptionsForTimeLimit,
                 onChange: onMinuteInputChange,
               })}
-              // onChange={onChange}
               name="timeLimit_minute"
               placeholder="00"
             />
@@ -178,7 +115,9 @@ const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
 
           <div className={styles.timerInput}>
             {!errors.timeLimit_minute && errors.alertTime_minute && (
-              <p className={styles.alarmWaring}>{errors.alertTime_minute.message}</p>
+              <p className={styles.alarmWaring} role="alert">
+                {errors.alertTime_minute.message}
+              </p>
             )}
             <input
               type="number"
@@ -187,8 +126,6 @@ const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
                 ...registerOptionsForAlert,
                 onChange: onHourInputChange,
               })}
-              // value={alertTime.hours ? alertTime.hours : 0}
-              // onChange={onChange}
               name="alertTime_hour"
               placeholder="00"
             />
@@ -200,8 +137,6 @@ const UploadTimer = forwardRef<HTMLInputElement, UploadTimerProps>(
                 ...registerOptionsForAlert,
                 onChange: onMinuteInputChange,
               })}
-              // value={alertTime.minutes ? alertTime.minutes : 0}
-              // onChange={onChange}
               name="alertTime_minute"
               placeholder="00"
             />

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_hooks/presentation.tsx
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_hooks/presentation.tsx
@@ -35,6 +35,10 @@ export const usePostPresentationData = (submitAction: 'save' | 'start') => {
     },
     onSuccess: async (response) => {
       const { presentationId } = await response.json();
+
+      queryClient.invalidateQueries({ queryKey: ['upload'] });
+      queryClient.invalidateQueries({ queryKey: ['practice'] });
+
       if (submitAction === 'start') {
         try {
           await queryClient.fetchQuery({
@@ -78,6 +82,8 @@ export const usePatchPresentationData = (submitAction: 'save' | 'start', slug: n
     },
     onSuccess: async (response) => {
       const { presentationId } = await response.json();
+      queryClient.invalidateQueries({ queryKey: ['upload'] });
+      queryClient.invalidateQueries({ queryKey: ['practice'] });
 
       if (submitAction === 'start') {
         try {

--- a/src/app/(afterlogin)/(common_navbar)/upload/[id]/_utils/calcTime.ts
+++ b/src/app/(afterlogin)/(common_navbar)/upload/[id]/_utils/calcTime.ts
@@ -1,0 +1,8 @@
+export const checkTimeValidate = (
+  limitHour: number,
+  limitMinute: number,
+  alertHour: number,
+  alertMinute: number,
+): boolean => {
+  return alertHour * 60 + alertMinute >= limitHour * 60 + limitMinute;
+};

--- a/src/app/(afterlogin)/_components/NavMenu.tsx
+++ b/src/app/(afterlogin)/_components/NavMenu.tsx
@@ -59,13 +59,13 @@ const NavMenu = () => {
     }
 
     if (name === 'home') {
-      // router.refresh();
       router.push('/home');
+      router.refresh();
       return;
     }
     if (name === 'feedback') {
-      // router.refresh();
       router.push('/feedback/list');
+      router.refresh();
       return;
     }
   };
@@ -95,6 +95,7 @@ const NavMenu = () => {
         cancelText="계속 작성하기"
         onOkayClick={() => {
           router.push('/home');
+          router.refresh();
           confirmHome.onClose();
         }}
       />
@@ -106,6 +107,7 @@ const NavMenu = () => {
         cancelText="계속 작성하기"
         onOkayClick={() => {
           router.push('/feedback/list');
+          router.refresh();
           confirmFeedback.onClose();
         }}
       />

--- a/src/app/(afterlogin)/_components/NavMenu.tsx
+++ b/src/app/(afterlogin)/_components/NavMenu.tsx
@@ -59,12 +59,12 @@ const NavMenu = () => {
     }
 
     if (name === 'home') {
-      router.refresh();
+      // router.refresh();
       router.push('/home');
       return;
     }
     if (name === 'feedback') {
-      router.refresh();
+      // router.refresh();
       router.push('/feedback/list');
       return;
     }

--- a/src/app/(afterlogin)/element-test/page.tsx
+++ b/src/app/(afterlogin)/element-test/page.tsx
@@ -45,7 +45,7 @@ export default function Page() {
   };
 
   const handleAlertModal = () => {
-    console.log('alert...');
+    // console.log('alert...');
     // modal.onClose();
     alert2.onOpen();
   };
@@ -140,7 +140,7 @@ export default function Page() {
           okayText="okay"
           cancelText="cancel"
           onOkayClick={() => {
-            console.log('okay okay ~');
+            // console.log('okay okay ~');
             confirm.onClose();
           }}
         />

--- a/src/app/(afterlogin)/practice/[id]/page.module.scss
+++ b/src/app/(afterlogin)/practice/[id]/page.module.scss
@@ -93,10 +93,11 @@
   }
 
   &__item {
+    overflow: hidden;
     width: 100%;
     height: 100%;
-    margin-top: 12px;
     border: 1px solid $gray-1;
+    margin-top: 12px;
     border-radius: 15px;
   }
 
@@ -126,4 +127,9 @@
   position: absolute;
   top: 75px;
   left: 35%;
+}
+
+.lastSlide {
+  width: 375px;
+  height: 210px;
 }

--- a/src/app/(afterlogin)/practice/[id]/page.tsx
+++ b/src/app/(afterlogin)/practice/[id]/page.tsx
@@ -204,7 +204,7 @@ export default function Page({ params }: { params: { id: string } }) {
   const content = watch('content') || '';
 
   const onSubmit = (data: FieldValues) => {
-    console.log('??????', data);
+    // console.log('??????', data);
   };
 
   return (

--- a/src/app/(afterlogin)/practice/[id]/page.tsx
+++ b/src/app/(afterlogin)/practice/[id]/page.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/navigation';
 import { FileService } from '@/services/client/file';
 import { FieldValues, useForm } from 'react-hook-form';
 import { CDN_BASE_URL } from '@/config/path';
+import LastSlide from '../_components/LastSlide';
 
 export default function Page({ params }: { params: { id: string } }) {
   const id = Number(params.id);
@@ -239,13 +240,15 @@ export default function Page({ params }: { params: { id: string } }) {
                 </h4>
                 <div className={styles.helper__item}>
                   {isLastSlide ? (
-                    <div>last ... </div>
+                    <div className={styles.lastSlide}>
+                      <LastSlide />
+                    </div>
                   ) : (
                     <Image
                       src={`${CDN_BASE_URL}/${data?.slides[slideSeq + 1].imageFilePath}`}
                       alt={`slide-${slideSeq + 1}`}
-                      width={370}
-                      height={200}
+                      width={375}
+                      height={210}
                       style={{ objectFit: 'contain', borderRadius: '16px' }}
                     />
                   )}

--- a/src/app/(afterlogin)/practice/_components/LastSlide.module.scss
+++ b/src/app/(afterlogin)/practice/_components/LastSlide.module.scss
@@ -1,0 +1,13 @@
+@import '@/styles/globals';
+@import '@/styles/mixins';
+
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  gap: 10px;
+  background-color: $gray-0;
+}

--- a/src/app/(afterlogin)/practice/_components/LastSlide.tsx
+++ b/src/app/(afterlogin)/practice/_components/LastSlide.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styles from './LastSlide.module.scss';
+
+const LastSlide = () => {
+  return (
+    <div className={styles.container}>
+      <p>고생하셨어요!</p>
+      <p>해당 슬라이드가 마지막 슬라이드에요.</p>
+    </div>
+  );
+};
+
+export default LastSlide;

--- a/src/app/(afterlogin)/practice/_hooks/useRecorder.ts
+++ b/src/app/(afterlogin)/practice/_hooks/useRecorder.ts
@@ -81,7 +81,7 @@ const useRecorder = (): ReturnType => {
 
   /** 녹음 시작하는 함수 */
   const startRecording = () => {
-    console.log('start ~');
+    // console.log('start ~');
     if (!stream) return;
 
     const mediaRecorder = new MediaRecorder(stream);
@@ -94,7 +94,7 @@ const useRecorder = (): ReturnType => {
 
     mediaRecorder.onstop = () => {
       const audioBlob = new Blob(audioChunks, { type: 'audio/mp3' });
-      console.log('on stop!...', audioBlob);
+      // console.log('on stop!...', audioBlob);
       setAudioBlob(audioBlob);
     };
 
@@ -107,7 +107,7 @@ const useRecorder = (): ReturnType => {
   /** 녹음 일시정지 함수 */
   const pauseRecording = () => {
     if (mediaRecorderRef.current && isRecording) {
-      console.log('pause ...');
+      // console.log('pause ...');
       mediaRecorderRef.current.pause();
       setIsRecording(false);
     }
@@ -116,7 +116,7 @@ const useRecorder = (): ReturnType => {
   /** 녹음 재개 함수 */
   const resumeRecording = () => {
     if (mediaRecorderRef.current && !isRecording) {
-      console.log('resume ...!');
+      // console.log('resume ...!');
       mediaRecorderRef.current.resume();
       setIsRecording(true);
     }
@@ -124,7 +124,7 @@ const useRecorder = (): ReturnType => {
 
   /** 녹음 멈추는 함수 */
   const stopRecording = async () => {
-    console.log('stop!');
+    // console.log('stop!');
     if (mediaRecorderRef.current && isRecording) {
       mediaRecorderRef.current.stop();
       setIsRecording(false);

--- a/src/app/(afterlogin)/socket-test/page.tsx
+++ b/src/app/(afterlogin)/socket-test/page.tsx
@@ -25,7 +25,7 @@ const Page = () => {
       const stomp = new Client({
         brokerURL: process.env.NEXT_PUBLIC_BASE_URL_SOCKET,
         debug: (str: string) => {
-          console.log(str);
+          // console.log(str);
         },
         reconnectDelay: 5000, //자동 재 연결
         heartbeatIncoming: 4000,
@@ -39,13 +39,13 @@ const Page = () => {
 
       // stomp client 연결 됐을 때 동작
       stomp.onConnect = () => {
-        console.log('WebSocket 연결이 열렸습니다.');
+        // console.log('WebSocket 연결이 열렸습니다.');
 
         stomp.subscribe(`/sub/practice/${sessionId}`, (frame) => {
           try {
             const message = JSON.parse(frame.body);
 
-            console.log(message);
+            // console.log(message);
           } catch (error) {
             console.error('오류가 발생했습니다:', error);
           }
@@ -82,7 +82,7 @@ const Page = () => {
     if (stompClient && stompClient.connected) {
       stompClient.deactivate();
     }
-    console.log('close...');
+    // console.log('close...');
   };
 
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10,7 +10,7 @@ body {
   margin: 0;
   padding: 0;
   min-height: 100%;
-  background: linear-gradient(to bottom, #f5f3ff 70%, #fff 100%);
+  background: linear-gradient(to bottom, #e3e0f5 70%, #fff 100%);
   background-attachment: fixed;
 }
 
@@ -67,7 +67,8 @@ h1,
 h2,
 h3,
 h4,
-h5 {
+h5,
+a {
   font-family:
     'Pretendard Variable',
     Pretendard,

--- a/src/services/client/feedback.ts
+++ b/src/services/client/feedback.ts
@@ -10,7 +10,7 @@ export const clientFeedbackApi = {
     const errorBody = await response.json();
     throw new Error(errorBody.message || '데이터를 불러오는 도중 문제가 발생했습니다');
   },
-  getFeedbackList: async ({ pageParam }: { pageParam?: number }) => {
+  getFeedbackList: async ({ pageParam }: { pageParam: number }) => {
     const response = await fetch_ClientAuth(`/api/feedbacks?page=${pageParam}&size=6`, {
       method: 'GET',
     });

--- a/src/services/client/file.ts
+++ b/src/services/client/file.ts
@@ -5,7 +5,6 @@ export const FileService = {
   fileUpload: async (file: File | Blob, filename?: string) => {
     const formData = new FormData();
     formData.append('file', file, filename);
-    console.log('form data : ', formData);
 
     const response = await fetch_ClientAuth(`/api/files/upload`, {
       method: 'POST',

--- a/src/services/server/feedback.ts
+++ b/src/services/server/feedback.ts
@@ -5,6 +5,7 @@ export const serverFeedbackApi = {
   getFeedbackInfo: async (feedbackId: number) => {
     const response = await fetch_ServerAuth(`${SERVER_BASE_URL}/api/feedbacks/${feedbackId}`, {
       method: 'GET',
+      cache: 'no-store',
     });
     // console.log('response');
     // console.log(response);
@@ -18,6 +19,7 @@ export const serverFeedbackApi = {
       `${SERVER_BASE_URL}/api/feedbacks?page=${pageParam}&size=6`,
       {
         method: 'GET',
+        cache: 'no-store',
       },
     );
     if (response.ok) return response;

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -10,6 +10,10 @@ export interface ValidtaionType {
   script: string;
   memo: string;
   deadlineDate: Value;
+  timeLimit_hour: number;
+  timeLimit_minute: number;
+  alertTime_hour: number;
+  alertTime_minute: number;
 }
 export interface MockUploadDataType {
   id?: number;

--- a/src/types/service.ts
+++ b/src/types/service.ts
@@ -272,7 +272,7 @@ export interface FeedbackListType {
       title: string;
       practiceDate: string;
       totalScore: number;
-      status: 'IN_PROGRESS' | 'DONE';
+      status: 'IN_PROGRESS' | 'DONE' | 'FAIL';
       thumbnailPath: string; // 임시
       createdAt: Date; // 임시
       modifiedAt: Date; // 임시


### PR DESCRIPTION
### 💁‍♂️ PR 개요

- QA 이슈 대응 - #62 

### 버그 수정
- [x] 피드백 queryKey와 발표 자료 queryKey중복 수정
- [x] 발표 업로드 페이지 이미지 짤림 현상 수정
- [x] 발표 자료 수정 이후에도 기존 캐싱 데이터를 사용하는 현상 해결
- [x] 발표 생성 단계에서 이미지가 없는 빈 슬라이드가 추가되는 현상 해결
- [x] 발표 삭제 후, 목록이 비었을 때 안내 모달창이 발생하지 않는 현상 해결
- [x] Navbar이동 시, 직전 발표 자료 데이터 갱신이 되지 않는 현상 해결

<br />

### 추가 기능 구현
- [x] 총 발표 시간>중간 알람 시간 유효성 로직 추가
- [x] 피드백 페이지에서 실시간 초 단위 피드백 refetch 구현
- [x] 발표 연습에서 마지막 페이지를 표시하는 컴포넌트 추가
- [x] 피드백 채점 결과_실패(FAIL) 타입 추가
- [x] 피드백 데이터 생성 실패 시에 사용되는 경고카드 생성
- [x] 피드백 목록이 비어었을때 사용되는 페이지 생성
- [x] 배경 그라데이션 색상을 조금 더 진하게 수정

<br/>

### 📷 스크린 샷 (선택)


<br/>

### 🗣 리뷰어한테 할 말 (선택)

<br/>

### 🧪 테스트 범위 (선택)

- 배포 환경 실사용 테스트